### PR TITLE
Add language selection and voice availability checks

### DIFF
--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -138,3 +138,11 @@
 .gn-nav-btn:hover {
   background-color: #005f91;
 }
+
+.gn-nav-select {
+  display: block;
+  margin-bottom: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  font-size: 14px;
+}

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, and full debug panel.
-Version: 2.5.23
+Version: 2.5.24
 Author: George Nicolaou
 */
 


### PR DESCRIPTION
## Summary
- add dropdown to choose navigation voice language
- store language preference and check if system voices exist
- prompt user when voice is missing
- style dropdown in navigation panel
- bump plugin version to 2.5.24

## Testing
- `node --check js/mapbox-init.js`
- `php -l gn-mapbox-plugin.php` *(fails: `bash: php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68418359fc548327a8f5b42db04d6c70