### PR TITLE
Add language parameter and improved voice prompt

### DIFF
--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -138,3 +138,11 @@
 .gn-nav-btn:hover {
   background-color: #005f91;
 }
+
+.gn-nav-select {
+  display: block;
+  margin-bottom: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  font-size: 14px;
+}

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, and full debug panel.
-Version: 2.5.23
+Version: 2.5.25
 Author: George Nicolaou
 */
 

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -4,6 +4,23 @@ document.addEventListener("DOMContentLoaded", function () {
   mapboxgl.accessToken = gnMapData.accessToken;
   const debugEnabled = gnMapData.debug === true;
   let coords = [];
+  const defaultLang = localStorage.getItem("gn_voice_lang") || "el-GR";
+
+  function getSelectedLanguage() {
+    const sel = document.getElementById("gn-language-select");
+    return sel ? sel.value : defaultLang;
+  }
+
+  function checkVoiceAvailability(lang) {
+    if (!window.speechSynthesis) return false;
+    const voices = window.speechSynthesis.getVoices();
+    if (!voices.length) return true;
+    const hasVoice = voices.some(v => v.lang === lang);
+    if (!hasVoice) {
+      alert(`Voice for ${lang} not found. Please install it from your system's language or speech settings to enable spoken directions.`);
+    }
+    return hasVoice;
+  }
 
   function log(...args) {
     if (debugEnabled) {
@@ -74,6 +91,10 @@ document.addEventListener("DOMContentLoaded", function () {
         <button class="gn-nav-btn" onclick="setMode('driving')">Driving</button>
         <button class="gn-nav-btn" onclick="setMode('walking')">Walking</button>
         <button class="gn-nav-btn" onclick="setMode('cycling')">Cycling</button>
+        <select id="gn-language-select" class="gn-nav-select">
+          <option value="en-US">English</option>
+          <option value="el-GR">Ελληνικά</option>
+        </select>
         <button class="gn-nav-btn" id="gn-start-nav">Start Navigation</button>
       </div>
     `;
@@ -89,6 +110,15 @@ document.addEventListener("DOMContentLoaded", function () {
       font-family: sans-serif;
     `;
     document.body.appendChild(navPanel);
+
+    const langSel = navPanel.querySelector("#gn-language-select");
+    if (langSel) {
+      langSel.value = defaultLang;
+      langSel.onchange = () => {
+        localStorage.setItem("gn_voice_lang", langSel.value);
+        checkVoiceAvailability(langSel.value);
+      };
+    }
 
     const header = navPanel.querySelector("div");
     header.onmousedown = function (e) {
@@ -145,17 +175,21 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     navigator.geolocation.getCurrentPosition(async (pos) => {
-      if (!window.speechSynthesis) {
-        alert("Voice guidance is not supported in your browser.");
-      } else if (!localStorage.getItem("gn_voice_prompted")) {
-        const consent = confirm("Enable Greek voice directions during navigation?");
-        if (!consent) localStorage.setItem("gn_voice_muted", true);
-        localStorage.setItem("gn_voice_prompted", true);
-      }
+        const lang = getSelectedLanguage();
+        if (!window.speechSynthesis) {
+          alert("Voice guidance is not supported in your browser.");
+        } else {
+          checkVoiceAvailability(lang);
+          if (!localStorage.getItem("gn_voice_prompted")) {
+            const consent = confirm(`Enable voice directions in ${lang}?`);
+            if (!consent) localStorage.setItem("gn_voice_muted", true);
+            localStorage.setItem("gn_voice_prompted", true);
+          }
+        }
       const userLngLat = [pos.coords.longitude, pos.coords.latitude];
       const allPoints = [userLngLat, ...coords];
       const coordPairs = allPoints.map(p => p.join(',')).join(';');
-      const url = `https://api.mapbox.com/directions/v5/mapbox/driving/${coordPairs}?geometries=geojson&overview=full&steps=true&annotations=duration,distance&access_token=${mapboxgl.accessToken}`;
+      const url = `https://api.mapbox.com/directions/v5/mapbox/driving/${coordPairs}?geometries=geojson&overview=full&steps=true&annotations=duration,distance&language=${lang}&access_token=${mapboxgl.accessToken}`;
 
       const res = await fetch(url);
       const data = await res.json();
@@ -196,8 +230,7 @@ document.addEventListener("DOMContentLoaded", function () {
       log(`Total route duration: ${totalDuration.toFixed(1)} minutes`);
       for (const step of steps) {
         const msg = new SpeechSynthesisUtterance(step.maneuver.instruction);
-        msg.lang = 'el-GR';
-        //msg.lang = 'en-GB';
+        msg.lang = lang;
         msg.rate = 0.95;
         msg.pitch = 1;
         msg.volume = 1.0;


### PR DESCRIPTION
## Summary
- bump plugin version to 2.5.25
- include selected language in directions request
- clarify voice installation prompt

## Testing
- `node --check js/mapbox-init.js`
- `php -l gn-mapbox-plugin.php` *(fails: `bash: php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68418359fc548327a8f5b42db04d6c70