### PR TITLE
Fix missing plugin version header

### DIFF
--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,6 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, and full debug panel.
+Version: 2.5.25
 Author: George Nicolaou
 */
 


### PR DESCRIPTION
## Summary
- restore the `Version` header in `gn-mapbox-plugin.php`

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68419e837a988327bf7c556261a02c06