### PR TITLE
Update plugin version

### DIFF
--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, and full debug panel.
-Version: 2.5.25
+Version: 2.5.26
 Author: George Nicolaou
 */
 


### PR DESCRIPTION
## Summary
- bump GN Mapbox plugin version to 2.5.26

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a89fc19483279e7cd8d001e837c1