### PR TITLE
Add language selection prompt for navigation voice

### DIFF
--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, and full debug panel.
-Version: 2.5.23
+Version: 2.5.24
 Author: George Nicolaou
 */
 


### PR DESCRIPTION
## Summary
- prompt for a preferred language when enabling voice navigation
- add UI button to change the voice language in the navigation panel
- make speech synthesis use the chosen language
- bump plugin version

## Testing
- `node -v`
- `node -c js/mapbox-init.js`

------
https://chatgpt.com/codex/tasks/task_e_6841822e4220832795a9e70cfd70823b