### PR TITLE
Add fallback locations dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Create `Map Location` posts with latitude and longitude fields and place the `[g
 ## Offline Caching
 A service worker caches Mapbox tiles for offline use once a page has been loaded online. The map will then continue working with the cached tiles when the network is unavailable.
 
+## Default Locations
+If no `Map Location` posts are found, coordinates are loaded from `data/locations.json`. Update this file to change the built-in locations.
+
 ## Changelog
 ### 2.7.0
 - Added photo gallery support for locations

--- a/data/locations.json
+++ b/data/locations.json
@@ -1,0 +1,18 @@
+[
+  {"title": "\u03a3\u03c4\u03c1\u03bf\u03c5\u03bc\u03c0\u03af", "content": "", "image": null, "gallery": [], "lat": 34.884028, "lng": 32.480806},
+  {"title": "\u039c\u03bf\u03c5\u03c3\u03b5\u03af\u03bf \u0391\u03b3\u03c1\u03bf\u03c4\u03b9\u03ba\u03ae\u03c2 \u0396\u03ce\u03b7\u03c2 \u0391\u03ba\u03ac\u03bc\u03b1 - \u039a\u03bf\u03b9\u03bd\u03bf\u03c4\u03b9\u03ba\u03cc \u03a3\u03c5\u03bc\u03b2\u03bf\u03cd\u03bb\u03b9\u03bf \u0394\u03c1\u03bf\u03cd\u03c3\u03b5\u03b9\u03b1\u03c2", "content": "", "image": null, "gallery": [], "lat": 34.959863, "lng": 32.397797},
+  {"title": "\u03a0\u03ad\u03c4\u03c1\u03b1 \u03c4\u03bf\u03c5 \u039d\u03b9\u03ba\u03bf\u03bb\u03ac", "content": "", "image": null, "gallery": [], "lat": 34.967306, "lng": 32.394056},
+  {"title": "\u03a0\u03ad\u03c4\u03c1\u03b1 \u03b7 \u039b\u03ac\u03bc\u03b9\u03b1", "content": "", "image": null, "gallery": [], "lat": 34.969667, "lng": 32.391861},
+  {"title": "\u0398\u03ad\u03b1 \u03c0\u03c1\u03bf\u03c2 \u039a\u03cc\u03bb\u03c0\u03bf \u03a0\u03cc\u03bb\u03b7\u03c2 \u03a7\u03c1\u03c5\u03c3\u03bf\u03c7\u03bf\u03cd\u03c2", "content": "", "image": null, "gallery": [], "lat": 34.972944, "lng": 32.390694},
+  {"title": "\u03a0\u03ad\u03c4\u03c1\u03b1", "content": "", "image": null, "gallery": [], "lat": 34.973444, "lng": 32.389667},
+  {"title": "\u0398\u03b5\u03b1 \u03c0\u03c1\u03bf\u03c2 \u03b1\u03b3\u03c1\u03bf\u03c4\u03b9\u03ba\u03bf \u03c4\u03bf\u03c0\u03b9\u03bf \u03ba\u03b1\u03b9 \u03b3\u03b5\u03c9\u03bc\u03bf\u03c1\u03c6\u03c9\u03bc\u03b1\u03c4\u03b1", "content": "", "image": null, "gallery": [], "lat": 34.973278, "lng": 32.389194},
+  {"title": "\u0391\u03c1\u03b3\u03ac\u03ba\u03b9 (\u0391\u03c1\u03b3\u03ac\u03ba\u03b9 \u03b5\u03c0\u03b9 \u03c4\u03b7\u03c2 \u03b4\u03b9\u03b1\u03b4\u03c1\u03bf\u03bc\u03ae\u03c2)", "content": "", "image": null, "gallery": [], "lat": 34.974194, "lng": 32.382861},
+  {"title": "\u0392\u03c1\u03cd\u03c3\u03b7 - \u039a\u03b1\u03c1\u03b1\u03bc\u03cc\u03bd\u03b1", "content": "", "image": null, "gallery": [], "lat": 34.984056, "lng": 32.376028},
+  {"title": "\u039f\u03b9\u03ba\u03b9\u03c3\u03bc\u03cc\u03c2 \u03a0\u03b9\u03c4\u03c4\u03cc\u03ba\u03bf\u03c0\u03bf\u03c2", "content": "", "image": null, "gallery": [], "lat": 34.976417, "lng": 32.376917},
+  {"title": "\u0398\u03ad\u03b1 \u03c0\u03c1\u03bf\u03c2 \u039a\u03cc\u03bb\u03c0\u03bf\u03c5\u03c2 \u039b\u03ac\u03c1\u03b1\u03c2", "content": "", "image": null, "gallery": [], "lat": 34.971988, "lng": 32.374484},
+  {"title": "\u03a3\u03b7\u03bc\u03b5\u03af\u03bf \u03b8\u03ad\u03b1\u03c2 \u03b3\u03b9\u03b1 \u039a.\u0391.\u03a1.\u0397", "content": "", "image": null, "gallery": [], "lat": 34.966528, "lng": 32.385556},
+  {"title": "\u0395\u03be\u03c9\u03ba\u03bb\u03ae\u03c3\u03b9 \u0391\u03b3\u03af\u03bf\u03c5 \u039b\u03bf\u03c5\u03ba\u03ac", "content": "", "image": null, "gallery": [], "lat": 34.966513, "lng": 32.385766},
+  {"title": "\u0395\u03ba\u03ba\u03bb\u03b7\u03c3\u03af\u03b1 \u0391\u03b3\u03af\u03bf\u03c5 \u0395\u03c0\u03b9\u03c6\u03b1\u03bd\u03af\u03bf\u03c5", "content": "", "image": null, "gallery": [], "lat": 34.962663, "lng": 32.397547},
+  {"title": "\u039a\u03ad\u03bd\u03c4\u03c1\u03bf \u039d\u03b5\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2 / \u03a0\u03bf\u03bb\u03b9\u03c4\u03b9\u03c3\u03c4\u03b9\u03ba\u03cc \u039a\u03ad\u03bd\u03c4\u03c1\u03bf", "content": "", "image": null, "gallery": [], "lat": 34.962806, "lng": 32.397444},
+  {"title": "\u0398\u03b5\u03b1\u03c4\u03c1\u03ac\u03ba\u03b9 \u03ba\u03b1\u03b9 \u03a0\u03b1\u03c1\u03b1\u03b4\u03bf\u03c3\u03b9\u03b1\u03ba\u03ae \u0392\u03c1\u03cd\u03c3\u03b7", "content": "", "image": null, "gallery": [], "lat": 34.963139, "lng": 32.397056}
+]

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -153,6 +153,22 @@ function gn_get_map_locations() {
 
     error_log('Total locations returned: ' . count($locations));
 
+    if (empty($locations)) {
+        $json_file = plugin_dir_path(__FILE__) . 'data/locations.json';
+        if (file_exists($json_file)) {
+            $json = file_get_contents($json_file);
+            $data = json_decode($json, true);
+            if (is_array($data)) {
+                $locations = $data;
+                error_log('Loaded ' . count($locations) . ' locations from JSON fallback');
+            } else {
+                error_log('Failed to parse locations JSON');
+            }
+        } else {
+            error_log('Fallback locations file not found');
+        }
+    }
+
     return $locations;
 }
 


### PR DESCRIPTION
## Summary
- provide fallback locations in `data/locations.json`
- load fallback locations if no posts exist
- document the default locations option

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9e0f681c8327842348936ec0aa1c