### PR TITLE
Add upload form shortcode in popups

### DIFF
--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -153,3 +153,12 @@
   background: #f0f5ff;
   border: 1px solid #b6d0ff;
 }
+
+.gn-upload-form {
+  margin-top: 10px;
+}
+.gn-upload-form form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -181,12 +181,14 @@ function gn_get_map_locations() {
             }
 
             $locations[] = [
-                'title'   => get_the_title(),
-                'content' => apply_filters('the_content', get_the_content()),
-                'image'   => get_the_post_thumbnail_url(get_the_ID(), 'medium'),
-                'gallery' => $gallery,
-                'lat'     => floatval($lat),
-                'lng'     => floatval($lng),
+                'id'          => get_the_ID(),
+                'title'       => get_the_title(),
+                'content'     => apply_filters('the_content', get_the_content()),
+                'image'       => get_the_post_thumbnail_url(get_the_ID(), 'medium'),
+                'gallery'     => $gallery,
+                'upload_form' => do_shortcode('[gn_photo_upload location="' . get_the_ID() . '"]'),
+                'lat'         => floatval($lat),
+                'lng'         => floatval($lng),
             ];
         }
     }

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -361,11 +361,13 @@ document.addEventListener("DOMContentLoaded", function () {
           loc.gallery.map(url => `<img src="${url}" alt="${loc.title}">`).join('') +
           '</div>'
         : '';
+      const uploadHTML = loc.upload_form ? `<div class="gn-upload-form">${loc.upload_form}</div>` : '';
       const popupHTML = `
         <div class="popup-content">
           ${loc.image ? `<img src="${loc.image}" alt="${loc.title}">` : ""}
           <h3>${loc.title}</h3>
           <div>${loc.content}</div>
+          ${uploadHTML}
           ${galleryHTML}
         </div>
       `;


### PR DESCRIPTION
## Summary
- include post ID and upload form HTML in location data
- show the upload form in each Mapbox popup
- style the optional upload form

## Testing
- `php` syntax check *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da5d9ca84832781e5f6f4cb64d5fa