### PR TITLE
Move upload form after gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ If no `Map Location` posts exist, the plugin will import the coordinates from
 to change the built-in locations.
 
 ## Changelog
+### 2.9.2
+- Upload form placed after gallery content in map popups
 ### 2.9.1
 - Upload form shortcode now appears in map popups
 ### 2.9.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.9.1
+Version: 2.9.2
 Author: George Nicolaou
 */
 

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -367,8 +367,8 @@ document.addEventListener("DOMContentLoaded", function () {
           ${loc.image ? `<img src="${loc.image}" alt="${loc.title}">` : ""}
           <h3>${loc.title}</h3>
           <div>${loc.content}</div>
-          ${uploadHTML}
           ${galleryHTML}
+          ${uploadHTML}
         </div>
       `;
       const popup = new mapboxgl.Popup({ offset: 25 }).setHTML(popupHTML);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.9.1
+Stable tag: 2.9.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -18,6 +18,8 @@ This plugin lets you add Map Location posts containing coordinates and display t
 3. Enter your Mapbox access token under **Settings → GN Mapbox**.
 
 == Changelog ==
+= 2.9.2 =
+* Upload form placed after gallery content in map popups
 = 2.9.1 =
 * Upload form shortcode now appears in map popups
 = 2.9.0 =


### PR DESCRIPTION
## Summary
- render photo upload form after gallery HTML
- bump plugin version to 2.9.2

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684da895d2f08327a5b4f57f7c6630a6