### PR TITLE
Handle fallback locations and prevent duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ Create `Map Location` posts with latitude and longitude fields and place the `[g
 A service worker caches Mapbox tiles for offline use once a page has been loaded online. The map will then continue working with the cached tiles when the network is unavailable.
 
 ## Default Locations
-If no `Map Location` posts exist, the plugin will import the coordinates from
-`data/locations.json` into the custom post type on activation. Update this file
-to change the built-in locations.
+If no `Map Location` posts exist, the plugin imports the coordinates from
+`data/locations.json` into the custom post type. When the JSON fallback is used
+at runtime, those locations are also created as posts so all features keep
+working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.9.4
+- Fallback locations now create posts if none exist and duplicate locations are avoided
 ### 2.9.3
 - Photo upload shortcode automatically appended to Map Location posts
 ### 2.9.2

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.9.3
+Stable tag: 2.9.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -18,6 +18,8 @@ This plugin lets you add Map Location posts containing coordinates and display t
 3. Enter your Mapbox access token under **Settings → GN Mapbox**.
 
 == Changelog ==
+= 2.9.4 =
+* Default locations from JSON now create posts if none exist and duplicates are prevented
 = 2.9.3 =
 * Ensure photo upload shortcode is appended to Map Location posts
 = 2.9.2 =


### PR DESCRIPTION
## Summary
- ensure fallback JSON locations are imported as posts
- avoid duplicate locations by name and coordinates
- bump version to 2.9.4
- document new behaviour

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db06a67288327bc80e0a388f5744c