### PR TITLE
Improve photo uploads with AJAX and admin approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+## Approving Uploaded Photos
+After visitors submit photos, they appear under **Media → Photo Approvals** in the WordPress admin. Review each image and click **Approve** to publish it to the corresponding location gallery.
+
 ## Offline Caching
 A service worker caches Mapbox tiles for offline use once a page has been loaded online. The map will then continue working with the cached tiles when the network is unavailable.
 
@@ -31,6 +34,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.10.0
+- Photo upload uses a single AJAX button and admin approval page
 ### 2.9.4
 - Fallback locations now create posts if none exist and duplicate locations are avoided
 ### 2.9.3

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -162,3 +162,17 @@
   flex-direction: column;
   gap: 6px;
 }
+.gn-photo-button {
+  background-color: #007cbf;
+  color: #fff;
+  padding: 8px 12px;
+  border: none;
+  cursor: pointer;
+}
+.gn-photo-button:hover {
+  background-color: #005f91;
+}
+.gn-upload-status {
+  margin-top: 5px;
+  font-size: 0.9em;
+}

--- a/js/gn-photo-upload.js
+++ b/js/gn-photo-upload.js
@@ -1,0 +1,25 @@
+jQuery(function($){
+    $(document).on('click','.gn-photo-button',function(e){
+        e.preventDefault();
+        $(this).closest('form').find('.gn-photo-file').trigger('click');
+    });
+
+    $(document).on('change','.gn-photo-file',function(){
+        const form = $(this).closest('form')[0];
+        const statusEl = $(form).find('.gn-upload-status');
+        const data = new FormData(form);
+        data.append('ajax','1');
+        statusEl.text('Uploading...');
+        fetch(form.action,{method:'POST',body:data,credentials:'same-origin'})
+            .then(res=>res.json())
+            .then(resp=>{
+                if(resp.success){
+                    statusEl.text('Upload received and awaiting approval.');
+                    form.reset();
+                } else {
+                    statusEl.text('Error uploading file.');
+                }
+            })
+            .catch(()=>statusEl.text('Error uploading file.'));
+    });
+});

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.9.4
+Stable tag: 2.10.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -18,6 +18,9 @@ This plugin lets you add Map Location posts containing coordinates and display t
 3. Enter your Mapbox access token under **Settings → GN Mapbox**.
 
 == Changelog ==
+= 2.10.0 =
+* Photo upload now uses a single button with AJAX
+* Added admin page for approving uploaded photos
 = 2.9.4 =
 * Default locations from JSON now create posts if none exist and duplicates are prevented
 = 2.9.3 =


### PR DESCRIPTION
## Summary
- allow AJAX photo uploads with a single button
- enqueue new upload script and add approval admin page
- style upload button
- document approval workflow
- bump version to 2.10.0

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684db38d5d088327b53641049e6fd2ca