### PR TITLE
Fix duplicate upload button

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.10.1
+- Fix duplicate upload form in popups
 ### 2.10.0
 - Photo upload uses a single AJAX button and admin approval page
 ### 2.9.4

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.10.0
+Version: 2.10.1
 Author: George Nicolaou
 */
 
@@ -253,10 +253,12 @@ function gn_get_map_locations() {
                 }
             }
 
+            $raw_content = get_the_content();
+            $raw_content = preg_replace('/\[gn_photo_upload[^\]]*\]/', '', $raw_content);
             $locations[] = [
                 'id'          => get_the_ID(),
                 'title'       => get_the_title(),
-                'content'     => apply_filters('the_content', get_the_content()),
+                'content'     => apply_filters('the_content', $raw_content),
                 'image'       => get_the_post_thumbnail_url(get_the_ID(), 'medium'),
                 'gallery'     => $gallery,
                 'upload_form' => do_shortcode('[gn_photo_upload location="' . get_the_ID() . '"]'),
@@ -293,10 +295,12 @@ function gn_get_map_locations() {
                     }
                 }
 
+                $raw_content = get_the_content();
+                $raw_content = preg_replace('/\[gn_photo_upload[^\]]*\]/', '', $raw_content);
                 $locations[] = [
                     'id'          => get_the_ID(),
                     'title'       => get_the_title(),
-                    'content'     => apply_filters('the_content', get_the_content()),
+                    'content'     => apply_filters('the_content', $raw_content),
                     'image'       => get_the_post_thumbnail_url(get_the_ID(), 'medium'),
                     'gallery'     => $gallery,
                     'upload_form' => do_shortcode('[gn_photo_upload location="' . get_the_ID() . '"]'),

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.10.0
+Stable tag: 2.10.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -18,6 +18,8 @@ This plugin lets you add Map Location posts containing coordinates and display t
 3. Enter your Mapbox access token under **Settings → GN Mapbox**.
 
 == Changelog ==
+= 2.10.1 =
+* Fix duplicate upload form in map popups
 = 2.10.0 =
 * Photo upload now uses a single button with AJAX
 * Added admin page for approving uploaded photos


### PR DESCRIPTION
## Summary
- filter out `gn_photo_upload` shortcode from map popups
- bump version to 2.10.1
- document change in README files

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684db595816c8327bb8178f335439bf3