### PR TITLE
Fix upload URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.10.2
+- Fixed upload form submission URL handling
+
 ### 2.10.1
 - Fix duplicate upload form in popups
 ### 2.10.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.10.1
+Version: 2.10.2
 Author: George Nicolaou
 */
 

--- a/js/gn-photo-upload.js
+++ b/js/gn-photo-upload.js
@@ -10,7 +10,8 @@ jQuery(function($){
         const data = new FormData(form);
         data.append('ajax','1');
         statusEl.text('Uploading...');
-        fetch(form.action,{method:'POST',body:data,credentials:'same-origin'})
+        const url = form.getAttribute('action');
+        fetch(url,{method:'POST',body:data,credentials:'same-origin'})
             .then(res=>res.json())
             .then(resp=>{
                 if(resp.success){

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.10.1
+Stable tag: 2.10.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -18,6 +18,8 @@ This plugin lets you add Map Location posts containing coordinates and display t
 3. Enter your Mapbox access token under **Settings → GN Mapbox**.
 
 == Changelog ==
+= 2.10.2 =
+* Fixed upload form submission URL handling
 = 2.10.1 =
 * Fix duplicate upload form in map popups
 = 2.10.0 =


### PR DESCRIPTION
## Summary
- fix uploading form action retrieval using `getAttribute`
- bump plugin version to 2.10.2
- document latest changes

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db960dd008327a5869283d70e527b