### PR TITLE
Improve photo upload approvals and debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 - Navigation panel with voice directions
 - Route animation and elevation chart
 - Optional debug panel
+- Verbose console debugging when enabled
 - **Offline map caching** (new in 2.6.0)
 - Upload a photo gallery for each location
 - Front-end photo uploads with admin approval
@@ -24,6 +25,9 @@ Create `Map Location` posts with latitude and longitude fields and place the `[g
 ## Approving Uploaded Photos
 After visitors submit photos, they appear under **Media → Photo Approvals** in the WordPress admin. Review each image and click **Approve** to publish it to the corresponding location gallery.
 
+## Debugging
+Enable the **Debug Panel** setting under **Settings → GN Mapbox** to output detailed logs to the browser console and on-screen panel.
+
 ## Offline Caching
 A service worker caches Mapbox tiles for offline use once a page has been loaded online. The map will then continue working with the cached tiles when the network is unavailable.
 
@@ -34,6 +38,11 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.11.0
+- Fix pending photo approval listing
+- Include location in upload success message
+- Verbose debugging available in browser console
+
 ### 2.10.2
 - Fixed upload form submission URL handling
 

--- a/js/gn-photo-upload.js
+++ b/js/gn-photo-upload.js
@@ -1,26 +1,36 @@
-jQuery(function($){
-    $(document).on('click','.gn-photo-button',function(e){
+jQuery(function ($) {
+    const debugEnabled = window.gnPhotoData && gnPhotoData.debug === true;
+    const log = (...args) => { if (debugEnabled) console.debug('[GN Photo]', ...args); };
+
+    $(document).on('click', '.gn-photo-button', function (e) {
         e.preventDefault();
+        log('Upload button clicked');
         $(this).closest('form').find('.gn-photo-file').trigger('click');
     });
 
-    $(document).on('change','.gn-photo-file',function(){
+    $(document).on('change', '.gn-photo-file', function () {
         const form = $(this).closest('form')[0];
         const statusEl = $(form).find('.gn-upload-status');
         const data = new FormData(form);
-        data.append('ajax','1');
-        statusEl.text('Uploading...');
+        data.append('ajax', '1');
         const url = form.getAttribute('action');
-        fetch(url,{method:'POST',body:data,credentials:'same-origin'})
-            .then(res=>res.json())
-            .then(resp=>{
-                if(resp.success){
-                    statusEl.text('Upload received and awaiting approval.');
+        statusEl.text('Uploading...');
+        log('Sending upload to', url);
+        fetch(url, { method: 'POST', body: data, credentials: 'same-origin' })
+            .then(res => res.json())
+            .then(resp => {
+                log('Upload response', resp);
+                if (resp.success) {
+                    const loc = resp.data && resp.data.title ? ' for ' + resp.data.title : '';
+                    statusEl.text('Upload received' + loc + ' and awaiting approval.');
                     form.reset();
                 } else {
                     statusEl.text('Error uploading file.');
                 }
             })
-            .catch(()=>statusEl.text('Error uploading file.'));
+            .catch(err => {
+                log('Upload error', err);
+                statusEl.text('Error uploading file.');
+            });
     });
 });

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.10.2
+Stable tag: 2.11.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -17,7 +17,14 @@ This plugin lets you add Map Location posts containing coordinates and display t
 2. Activate the plugin through the Plugins menu.
 3. Enter your Mapbox access token under **Settings → GN Mapbox**.
 
+== Debugging ==
+Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose logs to the browser console.
+
 == Changelog ==
+= 2.11.0 =
+* Fixed pending uploads missing from Approvals screen
+* Upload success message shows location name
+* Added verbose console debugging option
 = 2.10.2 =
 * Fixed upload form submission URL handling
 = 2.10.1 =


### PR DESCRIPTION
## Summary
- bump to version 2.11.0
- show location name after a successful upload
- return pending uploads correctly on approval page
- add verbose console debugging for uploads
- document debugging and new behaviour

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbb7f5e5083279103b3f9eb2f6c48