### PR TITLE
Add detailed feature docs and bump plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,18 @@
 This WordPress plugin displays custom post type locations on a Mapbox map. It allows visitors to view markers, follow routes and even get spoken navigation.
 
 ## Features
-- Custom post type for locations
-- Map display via shortcode `[gn_map]`
-- Navigation panel with voice directions
-- Route animation and elevation chart
-- Optional debug panel
-- Verbose console debugging when enabled
-- **Offline map caching** (new in 2.6.0)
-- Upload a photo gallery for each location
-- Front-end photo uploads with admin approval
-- Photo upload form available inside map popups
+- "Map Location" custom post type stores coordinates, descriptions and optional photo galleries.
+- Embed a full Mapbox map anywhere with the `[gn_map]` shortcode.
+- Draggable navigation panel provides driving, walking and cycling directions with voice guidance.
+- Spoken instructions use the browser's speech synthesis API and can be muted or unmuted.
+- Animated route line tracks progress and may be paused or resumed at any time.
+- Optional elevation graph and route statistics.
+- On-screen debug panel and console logs when debugging is enabled.
+- Service worker caches Mapbox tiles so viewed maps continue working offline.
+- Front-end photo uploads let visitors contribute images pending admin approval.
+- Upload forms appear automatically in each map popup and within the location post.
+- Example locations from `data/locations.json` are imported if none exist.
+- Built-in update checker fetches new versions directly from GitHub.
 
 ## Installation
 1. Upload the plugin to your `/wp-content/plugins/` directory.
@@ -38,6 +40,9 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.12.0
+- Expanded documentation with detailed feature descriptions
+
 ### 2.11.0
 - Fix pending photo approval listing
 - Include location in upload success message

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.11.0
+Version: 2.12.0
 Author: George Nicolaou
 */
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,14 +3,26 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.11.0
+Stable tag: 2.12.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Display custom map locations using Mapbox with navigation, voice directions and offline caching.
+Display custom map locations on a Mapbox-powered map complete with voice guided navigation, animated routes, offline caching and photo galleries.
 
 == Description ==
-This plugin lets you add Map Location posts containing coordinates and display them with a shortcode. It includes a navigation panel with voice instructions, an optional debug mode and now offline map tile caching via service worker.
+GN Mapbox Locations with ACF creates a **Map Location** post type for storing coordinates, descriptions and images. Place the `[gn_map]` shortcode anywhere to display an interactive map. A draggable navigation panel gives visitors driving, walking or cycling directions with spoken instructions that can be muted. Routes can be animated and paused or resumed, while a service worker caches tiles for offline use. A debug panel outputs verbose logs when enabled. Visitors can submit photos from the front end which administrators approve before publishing. Example locations are automatically imported if none exist.
+== Features ==
+* "Map Location" custom post type storing coordinates, descriptions and galleries.
+* `[gn_map]` shortcode displays an interactive Mapbox map with all locations.
+* Draggable navigation panel for driving, walking or cycling directions with voice guidance.
+* Voice instructions can be muted or unmuted and support multiple languages.
+* Animated route line with optional elevation graph and statistics.
+* Debug panel outputs verbose logs on screen and to the browser console.
+* Offline map tile caching via service worker.
+* Visitors may upload photos on the front end; submissions require admin approval.
+* Upload forms automatically appear in map popups and inside each location post.
+* Example locations from `data/locations.json` are imported when none exist.
+* Automatic update checks from GitHub.
 
 == Installation ==
 1. Upload the plugin folder to `/wp-content/plugins/`.
@@ -21,6 +33,9 @@ This plugin lets you add Map Location posts containing coordinates and display t
 Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose logs to the browser console.
 
 == Changelog ==
+= 2.12.0 
+* Expanded documentation with detailed feature descriptions
+
 = 2.11.0 =
 * Fixed pending uploads missing from Approvals screen
 * Upload success message shows location name


### PR DESCRIPTION
## Summary
- expand feature lists in docs
- bump plugin version to 2.12.0
- update changelogs

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684dbe44a0988327a83488e5577e6b70