### PR TITLE
Fix upload redirect issue and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.13.0
+- Prevent default form submission to avoid redirect errors
+
 ### 2.12.0
 - Expanded documentation with detailed feature descriptions
 

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.12.0
+Version: 2.13.0
 Author: George Nicolaou
 */
 

--- a/js/gn-photo-upload.js
+++ b/js/gn-photo-upload.js
@@ -2,14 +2,7 @@ jQuery(function ($) {
     const debugEnabled = window.gnPhotoData && gnPhotoData.debug === true;
     const log = (...args) => { if (debugEnabled) console.debug('[GN Photo]', ...args); };
 
-    $(document).on('click', '.gn-photo-button', function (e) {
-        e.preventDefault();
-        log('Upload button clicked');
-        $(this).closest('form').find('.gn-photo-file').trigger('click');
-    });
-
-    $(document).on('change', '.gn-photo-file', function () {
-        const form = $(this).closest('form')[0];
+    function uploadForm(form) {
         const statusEl = $(form).find('.gn-upload-status');
         const data = new FormData(form);
         data.append('ajax', '1');
@@ -32,5 +25,21 @@ jQuery(function ($) {
                 log('Upload error', err);
                 statusEl.text('Error uploading file.');
             });
+    }
+
+    $(document).on('click', '.gn-photo-button', function (e) {
+        e.preventDefault();
+        log('Upload button clicked');
+        $(this).closest('form').find('.gn-photo-file').trigger('click');
+    });
+
+    $(document).on('submit', '.gn-photo-upload-form', function (e) {
+        e.preventDefault();
+        uploadForm(this);
+    });
+
+    $(document).on('change', '.gn-photo-file', function () {
+        const form = $(this).closest('form')[0];
+        uploadForm(form);
     });
 });

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.12.0
+Stable tag: 2.13.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -33,7 +33,9 @@ GN Mapbox Locations with ACF creates a **Map Location** post type for storing co
 Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose logs to the browser console.
 
 == Changelog ==
-= 2.12.0 
+= 2.13.0 =
+* Prevent default form submission to avoid redirect errors
+= 2.12.0
 * Expanded documentation with detailed feature descriptions
 
 = 2.11.0 =


### PR DESCRIPTION
## Summary
- prevent photo upload forms from submitting normally
- bump plugin version to 2.13.0
- document change in readme files

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684dc03cf68c8327bcf946cd8af6d36c