### PR TITLE
Add WPML compatibility and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.14.0
+- Added WPML compatibility and translations
 ### 2.13.1
 - Fix upload URL when a hidden `action` field overrides the form property
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.13.1
+Stable tag: 2.14.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -33,6 +33,8 @@ GN Mapbox Locations with ACF creates a **Map Location** post type for storing co
 Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose logs to the browser console.
 
 == Changelog ==
+= 2.14.0 =
+* Added WPML compatibility and translations
 = 2.13.1 =
 * Fix upload URL when hidden `action` field overrides the form property
 = 2.13.0 =

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,0 +1,15 @@
+<wpml-config>
+    <custom-fields>
+        <custom-field action="copy">latitude</custom-field>
+        <custom-field action="copy">longitude</custom-field>
+        <custom-field action="copy">_gn_location_photos</custom-field>
+        <custom-field action="copy">_gn_pending_photos</custom-field>
+    </custom-fields>
+    <custom-types>
+        <custom-type translate="1">map_location</custom-type>
+    </custom-types>
+    <admin-texts>
+        <key name="gn_mapbox_token"/>
+        <key name="gn_mapbox_debug"/>
+    </admin-texts>
+</wpml-config>


### PR DESCRIPTION
## Summary
- make mapbox strings translatable
- add WPML config file
- bump plugin version to 2.14.0
- document new changes in README files

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc60402088327b268f177ef778136