### PR TITLE
Add lightbox for popup images

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,20 @@
 This WordPress plugin displays custom post type locations on a Mapbox map. It allows visitors to view markers, follow routes and even get spoken navigation.
 
 ## Features
-- "Map Location" custom post type stores coordinates, descriptions and optional photo galleries.
-- Embed a full Mapbox map anywhere with the `[gn_map]` shortcode.
-- Draggable navigation panel provides driving, walking and cycling directions with voice guidance.
-- Spoken instructions use the browser's speech synthesis API and can be muted or unmuted.
-- Animated route line tracks progress and may be paused or resumed at any time.
-- Optional elevation graph and route statistics.
+- "Map Location" custom post type stores coordinates, descriptions and unlimited gallery images.
+- `[gn_map]` shortcode embeds a fully interactive Mapbox map anywhere on your site.
+- Responsive popups display images, descriptions and photo upload forms.
+- Gallery and featured images open in a lightbox that scales beautifully on all devices.
+- Draggable navigation panel offers driving, walking and cycling directions with voice guidance.
+- Spoken instructions use the browser speech API and can be muted or unmuted at any time.
+- Animated route line with optional elevation graph and real-time statistics.
 - On-screen debug panel and console logs when debugging is enabled.
 - Service worker caches Mapbox tiles so viewed maps continue working offline.
-- Front-end photo uploads let visitors contribute images pending admin approval.
-- Upload forms appear automatically in each map popup and within the location post.
+- Visitors can upload photos from the front end; submissions require admin approval.
+- Upload forms automatically appear in map popups and inside each location post.
 - Example locations from `data/locations.json` are imported if none exist.
 - Built-in update checker fetches new versions directly from GitHub.
+- Ready for translation and WPML compatible.
 
 ## Installation
 1. Upload the plugin to your `/wp-content/plugins/` directory.
@@ -40,6 +42,9 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.15.0
+- Images in popups now open in a responsive lightbox
+- Documentation expanded with full feature list
 ### 2.14.0
 - Added WPML compatibility and translations
 ### 2.13.1

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -46,6 +46,7 @@
   border-radius: 6px !important;
   object-fit: contain !important;
   display: block !important;
+  cursor: pointer !important;
 }
 
 /* Embedded video support */
@@ -175,4 +176,35 @@
 .gn-upload-status {
   margin-top: 5px;
   font-size: 0.9em;
+}
+
+/* Popup image lightbox */
+#gn-lightbox {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 10000;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+#gn-lightbox.visible {
+  display: flex;
+}
+
+#gn-lightbox img {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+#gn-lightbox .gn-lightbox-close {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  color: #fff;
+  font-size: 32px;
+  cursor: pointer;
 }

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.14.0
+Version: 2.15.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -175,6 +175,26 @@ document.addEventListener("DOMContentLoaded", function () {
     panel.querySelector("div:last-child").appendChild(btn);
   }
 
+  function setupLightbox() {
+    const overlay = document.createElement('div');
+    overlay.id = 'gn-lightbox';
+    overlay.innerHTML = '<span class="gn-lightbox-close">&times;</span><img>';
+    document.body.appendChild(overlay);
+
+    overlay.addEventListener('click', e => {
+      if (e.target === overlay || e.target.classList.contains('gn-lightbox-close')) {
+        overlay.classList.remove('visible');
+      }
+    });
+
+    document.addEventListener('click', e => {
+      if (e.target.matches('#gn-mapbox-map .popup-content img')) {
+        overlay.querySelector('img').src = e.target.src;
+        overlay.classList.add('visible');
+      }
+    });
+  }
+
   window.setMode = function (mode) {
     log("Navigation mode set to:", mode);
   };
@@ -256,6 +276,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
   setupDebugPanel();
   setupNavPanel();
+  setupLightbox();
 
   function animateAlongRoute(routeCoords) {
     if (!routeCoords || routeCoords.length < 2) return;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.14.0
+Stable tag: 2.15.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -13,7 +13,9 @@ Display custom map locations on a Mapbox-powered map complete with voice guided 
 GN Mapbox Locations with ACF creates a **Map Location** post type for storing coordinates, descriptions and images. Place the `[gn_map]` shortcode anywhere to display an interactive map. A draggable navigation panel gives visitors driving, walking or cycling directions with spoken instructions that can be muted. Routes can be animated and paused or resumed, while a service worker caches tiles for offline use. A debug panel outputs verbose logs when enabled. Visitors can submit photos from the front end which administrators approve before publishing. Example locations are automatically imported if none exist.
 == Features ==
 * "Map Location" custom post type storing coordinates, descriptions and galleries.
-* `[gn_map]` shortcode displays an interactive Mapbox map with all locations.
+* `[gn_map]` shortcode embeds an interactive Mapbox map anywhere.
+* Responsive popups show images, descriptions and an upload form.
+* Gallery and featured images open in a lightbox and scale to any screen.
 * Draggable navigation panel for driving, walking or cycling directions with voice guidance.
 * Voice instructions can be muted or unmuted and support multiple languages.
 * Animated route line with optional elevation graph and statistics.
@@ -23,6 +25,7 @@ GN Mapbox Locations with ACF creates a **Map Location** post type for storing co
 * Upload forms automatically appear in map popups and inside each location post.
 * Example locations from `data/locations.json` are imported when none exist.
 * Automatic update checks from GitHub.
+* Ready for translation and WPML compatible.
 
 == Installation ==
 1. Upload the plugin folder to `/wp-content/plugins/`.
@@ -33,6 +36,9 @@ GN Mapbox Locations with ACF creates a **Map Location** post type for storing co
 Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose logs to the browser console.
 
 == Changelog ==
+= 2.15.0 =
+* Images in popups now open in a responsive lightbox
+* Expanded documentation of all features
 = 2.14.0 =
 * Added WPML compatibility and translations
 = 2.13.1 =


### PR DESCRIPTION
## Summary
- open popup images in a lightbox and make them responsive
- style the lightbox overlay
- bump plugin version to 2.15.0
- document all plugin features

## Testing
- `node --check js/mapbox-init.js`

------
https://chatgpt.com/codex/tasks/task_e_684dca14d41c8327a6363803abe56e6d