### PR TITLE
Make nav panel compact

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.16.0
+- Navigation panel more compact
 ### 2.15.0
 - Images in popups now open in a responsive lightbox
 - Documentation expanded with full feature list

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -127,13 +127,13 @@
 
 .gn-nav-btn {
   display: block;
-  margin-bottom: 8px;
+  margin-bottom: 4px;
   width: 100%;
-  padding: 8px 10px;
+  padding: 6px 8px;
   background-color: #007cbf;
   color: #fff;
   border: none;
-  font-size: 14px;
+  font-size: 13px;
   cursor: pointer;
 }
 .gn-nav-btn:hover {
@@ -142,10 +142,10 @@
 
 .gn-nav-select {
   display: block;
-  margin-bottom: 8px;
+  margin-bottom: 4px;
   width: 100%;
-  padding: 6px 8px;
-  font-size: 14px;
+  padding: 4px 6px;
+  font-size: 13px;
 }
 
 .gn-upload-msg {

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.15.0
+Version: 2.16.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -98,7 +98,7 @@ document.addEventListener("DOMContentLoaded", function () {
     navPanel.id = "gn-nav-panel";
     navPanel.innerHTML = `
       <div style="cursor: move; background: #333; color: #fff; padding: 6px;">☰ Navigation Panel</div>
-      <div style="padding: 10px; background: white;">
+      <div style="padding: 6px; background: white;">
         <button class="gn-nav-btn" onclick="setMode('driving')">Driving</button>
         <button class="gn-nav-btn" onclick="setMode('walking')">Walking</button>
         <button class="gn-nav-btn" onclick="setMode('cycling')">Cycling</button>
@@ -113,7 +113,7 @@ document.addEventListener("DOMContentLoaded", function () {
       position: fixed;
       top: 100px;
       left: 10px;
-      width: 200px;
+      width: 160px;
       z-index: 9998;
       border: 1px solid #ccc;
       box-shadow: 0 2px 5px rgba(0,0,0,0.3);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.15.0
+Stable tag: 2.16.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -36,6 +36,8 @@ GN Mapbox Locations with ACF creates a **Map Location** post type for storing co
 Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose logs to the browser console.
 
 == Changelog ==
+= 2.16.0 =
+* Navigation panel more compact
 = 2.15.0 =
 * Images in popups now open in a responsive lightbox
 * Expanded documentation of all features


### PR DESCRIPTION
## Summary
- tweak nav panel styles for smaller layout
- bump plugin version to 2.16.0
- document new version in changelogs

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684dcc8d50048327a905a0d458c84741