### PR TITLE
Improve Mapbox navigation UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.17.0
+- Satellite view by default
+- Navigation mode dropdown and icon buttons
+- Distance/time panel and improved voice instructions
 ### 2.16.0
 - Navigation panel more compact
 ### 2.15.0

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -148,6 +148,11 @@
   font-size: 13px;
 }
 
+#gn-distance-panel {
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+
 .gn-upload-msg {
   margin-bottom: 10px;
   padding: 8px;

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.16.0
+Version: 2.17.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.16.0
+Stable tag: 2.17.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -36,6 +36,8 @@ GN Mapbox Locations with ACF creates a **Map Location** post type for storing co
 Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose logs to the browser console.
 
 == Changelog ==
+= 2.17.0 =
+* Satellite map default, improved navigation controls
 = 2.16.0 =
 * Navigation panel more compact
 = 2.15.0 =


### PR DESCRIPTION
## Summary
- default to satellite view
- add navigation dropdown, icons, and distance panel
- update navigation to use selected mode and show remaining distance
- load initial route via Directions API for snapped geometry
- document changes and bump version

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef146504883279ad45150193fcee3