### PR TITLE
Add map language selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 - Responsive popups display images, descriptions and photo upload forms.
 - Gallery and featured images open in a lightbox that scales beautifully on all devices.
 - Draggable navigation panel offers driving, walking and cycling directions with voice guidance.
+- Map labels and voice guidance follow the selected language.
 - Spoken instructions use the browser speech API and can be muted or unmuted at any time.
 - Animated route line with optional elevation graph and real-time statistics.
 - On-screen debug panel and console logs when debugging is enabled.
@@ -42,6 +43,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.18.0
+- Map labels switch languages along with voice instructions
 ### 2.17.0
 - Satellite view by default
 - Navigation mode dropdown and icon buttons

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.17.0
+Version: 2.18.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -221,7 +221,8 @@ function gn_enqueue_mapbox_assets() {
     wp_enqueue_style('gn-mapbox-style', plugin_dir_url(__FILE__) . 'css/mapbox-style.css');
     wp_enqueue_script('mapbox-gl', 'https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js', [], null, true);
     wp_enqueue_script('chartjs', 'https://cdn.jsdelivr.net/npm/chart.js', [], null, true);
-    wp_enqueue_script('gn-mapbox-init', plugin_dir_url(__FILE__) . 'js/mapbox-init.js', ['jquery'], null, true);
+    wp_enqueue_script('mapbox-gl-language', plugin_dir_url(__FILE__) . 'js/mapbox-gl-language.js', ['mapbox-gl'], null, true);
+    wp_enqueue_script('gn-mapbox-init', plugin_dir_url(__FILE__) . 'js/mapbox-init.js', ['jquery', 'mapbox-gl-language'], null, true);
     wp_enqueue_script('gn-sw-register', plugin_dir_url(__FILE__) . 'js/sw-register.js', [], null, true);
     wp_enqueue_script('gn-photo-upload', plugin_dir_url(__FILE__) . 'js/gn-photo-upload.js', ['jquery'], null, true);
 

--- a/js/mapbox-gl-language.js
+++ b/js/mapbox-gl-language.js
@@ -1,0 +1,173 @@
+/**
+ * Create a new [Mapbox GL JS plugin](https://www.mapbox.com/blog/build-mapbox-gl-js-plugins/) that
+ * modifies the layers of the map style to use the `text-field` that matches the browser language.
+ * As of Mapbox GL Language v1.0.0, this plugin no longer supports token values (e.g. `{name}`). v1.0+ expects the `text-field`
+ * property of a style to use an [expression](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/) of the form `['get', 'name_en']` or `['get', 'name']`; these expressions can be nested. Note that `get` expressions used as inputs to other expressions may not be handled by this plugin. For example:
+ * ```
+ * ["match",
+ *   ["get", "name"],
+ *   "California",
+ *   "Golden State",
+ *   ["coalesce",
+ *     ["get", "name_en"],
+ *     ["get", "name"]
+ *   ]
+ * ]
+ * ```
+ * Only styles based on [Mapbox v8 styles](https://docs.mapbox.com/help/troubleshooting/streets-v8-migration-guide/) are supported.
+ *
+ * @constructor
+ * @param {object} options - Options to configure the plugin.
+ * @param {string[]} [options.supportedLanguages] - List of supported languages
+ * @param {Function} [options.languageTransform] - Custom style transformation to apply
+ * @param {RegExp} [options.languageField=/^name_/] - RegExp to match if a text-field is a language field
+ * @param {Function} [options.getLanguageField] - Given a language choose the field in the vector tiles
+ * @param {string} [options.languageSource] - Name of the source that contains the different languages.
+ * @param {string} [options.defaultLanguage] - Name of the default language to initialize style after loading.
+ * @param {string[]} [options.excludedLayerIds] - Name of the layers that should be excluded from translation.
+ */
+function MapboxLanguage(options) {
+  options = Object.assign({}, options);
+  if (!(this instanceof MapboxLanguage)) {
+    throw new Error('MapboxLanguage needs to be called with the new keyword');
+  }
+
+  this.setLanguage = this.setLanguage.bind(this);
+  this._initialStyleUpdate = this._initialStyleUpdate.bind(this);
+
+  this._defaultLanguage = options.defaultLanguage;
+  this._isLanguageField = options.languageField || /^name_/;
+  this._getLanguageField = options.getLanguageField || function nameField(language) {
+    return language === 'mul' ? 'name' : `name_${language}`;
+  };
+  this._languageSource = options.languageSource || null;
+  this._languageTransform = options.languageTransform;
+  this._excludedLayerIds = options.excludedLayerIds || [];
+  this.supportedLanguages = options.supportedLanguages || ['ar', 'de', 'en', 'es', 'fr', 'it', 'ja', 'ko', 'mul', 'pt', 'ru', 'vi', 'zh-Hans', 'zh-Hant'];
+}
+
+const isTokenField = /^\{name/;
+function isFlatExpressionField(isLangField, property) {
+  const isGetExpression = Array.isArray(property) && property[0] === 'get';
+  if (isGetExpression && isTokenField.test(property[1])) {
+    console.warn('This plugin no longer supports the use of token syntax (e.g. {name}). Please use a get expression. See https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/ for more details.');
+  }
+
+  return isGetExpression && isLangField.test(property[1]);
+}
+
+function adaptNestedExpressionField(isLangField, property, languageFieldName) {
+  if (Array.isArray(property)) {
+    for (let i = 1; i < property.length; i++) {
+      if (Array.isArray(property[i])) {
+        if (isFlatExpressionField(isLangField, property[i])) {
+          property[i][1] = languageFieldName;
+        }
+        adaptNestedExpressionField(isLangField, property[i], languageFieldName);
+      }
+    }
+  }
+}
+
+function adaptPropertyLanguage(isLangField, property, languageFieldName) {
+  if (isFlatExpressionField(isLangField, property)) {
+    property[1] = languageFieldName;
+  }
+
+  adaptNestedExpressionField(isLangField, property, languageFieldName);
+
+  // handle special case of bare ['get', 'name'] expression by wrapping it in a coalesce statement
+  if (property[0] === 'get' && property[1] === 'name') {
+    const defaultProp = property.slice();
+    const adaptedProp = ['get', languageFieldName];
+    property = ['coalesce', adaptedProp, defaultProp];
+  }
+
+  return property;
+}
+
+function changeLayerTextProperty(isLangField, layer, languageFieldName, excludedLayerIds) {
+  if (layer.layout && layer.layout['text-field'] && excludedLayerIds.indexOf(layer.id) === -1) {
+    return Object.assign({}, layer, {
+      layout: Object.assign({}, layer.layout, {
+        'text-field': adaptPropertyLanguage(isLangField, layer.layout['text-field'], languageFieldName)
+      })
+    });
+  }
+  return layer;
+}
+
+function findStreetsSource(style) {
+  const sources = Object.keys(style.sources).filter((sourceName) => {
+    const url = style.sources[sourceName].url;
+    // the source URL can reference the source version or the style version
+    // this check and the error forces users to migrate to styles using source version 8
+    return url && url.indexOf('mapbox.mapbox-streets-v8') > -1 || /mapbox-streets-v[1-9][1-9]/.test(url);
+  });
+  if (!sources.length) throw new Error('If using MapboxLanguage with a Mapbox style, the style must be based on vector tile version 8, e.g. "streets-v11"');
+  return sources[0];
+}
+
+/**
+ * Explicitly change the language for a style.
+ * @param {object} style - Mapbox GL style to modify
+ * @param {string} language - The language iso code
+ * @returns {object} the modified style
+ */
+MapboxLanguage.prototype.setLanguage = function (style, language) {
+  if (this.supportedLanguages.indexOf(language) < 0) throw new Error(`Language ${  language  } is not supported`);
+  const streetsSource = this._languageSource || findStreetsSource(style);
+  if (!streetsSource) return style;
+
+  const field = this._getLanguageField(language);
+  const isLangField = this._isLanguageField;
+  const excludedLayerIds = this._excludedLayerIds;
+  const changedLayers = style.layers.map((layer) => {
+    if (layer.source === streetsSource) return changeLayerTextProperty(isLangField, layer, field, excludedLayerIds);
+    return layer;
+  });
+
+  const languageStyle = Object.assign({}, style, {
+    layers: changedLayers
+  });
+
+  return this._languageTransform ? this._languageTransform(languageStyle, language) : languageStyle;
+};
+
+MapboxLanguage.prototype._initialStyleUpdate = function () {
+  const style = this._map.getStyle();
+  const language = this._defaultLanguage || browserLanguage(this.supportedLanguages);
+
+  this._map.setStyle(this.setLanguage(style, language));
+};
+
+function browserLanguage(supportedLanguages) {
+  const language = navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage);
+  const parts = language && language.split('-');
+  let languageCode = language;
+  if (parts.length > 1) {
+    languageCode = parts[0];
+  }
+  if (supportedLanguages.indexOf(languageCode) > -1) {
+    return languageCode;
+  }
+  return null;
+}
+
+MapboxLanguage.prototype.onAdd = function (map) {
+  this._map = map;
+  this._map.on('style.load', this._initialStyleUpdate);
+  this._container = document.createElement('div');
+  return this._container;
+};
+
+MapboxLanguage.prototype.onRemove = function () {
+  this._map.off('style.load', this._initialStyleUpdate);
+  this._map = undefined;
+};
+
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+  module.exports = MapboxLanguage;
+} else {
+  window.MapboxLanguage = MapboxLanguage;
+}

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -5,7 +5,13 @@ document.addEventListener("DOMContentLoaded", function () {
   const debugEnabled = gnMapData.debug === true;
   let coords = [];
   let navigationMode = "driving";
+  let map;
+  let languageControl;
   const defaultLang = localStorage.getItem("gn_voice_lang") || "el-GR";
+
+  function mapLangPart(code) {
+    return code.split("-")[0];
+  }
 
   function getSelectedLanguage() {
     const sel = document.getElementById("gn-language-select");
@@ -137,6 +143,10 @@ document.addEventListener("DOMContentLoaded", function () {
       langSel.onchange = () => {
         localStorage.setItem("gn_voice_lang", langSel.value);
         checkVoiceAvailability(langSel.value);
+        if (languageControl && map) {
+          const code = mapLangPart(langSel.value);
+          map.setStyle(languageControl.setLanguage(map.getStyle(), code));
+        }
       };
     }
 
@@ -388,7 +398,7 @@ document.addEventListener("DOMContentLoaded", function () {
     move();
   }
 
-  const map = new mapboxgl.Map({
+  map = new mapboxgl.Map({
     container: "gn-mapbox-map",
     style: "mapbox://styles/mapbox/satellite-streets-v11",
     center: [32.3923713, 34.96211],
@@ -396,6 +406,11 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
   map.addControl(new mapboxgl.NavigationControl(), "top-left");
+  languageControl = new MapboxLanguage({
+    supportedLanguages: ["en", "el"],
+    defaultLanguage: mapLangPart(defaultLang)
+  });
+  map.addControl(languageControl);
 
   map.on("load", () => {
     log("Map loaded");

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.17.0
+Stable tag: 2.18.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -36,6 +36,8 @@ GN Mapbox Locations with ACF creates a **Map Location** post type for storing co
 Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose logs to the browser console.
 
 == Changelog ==
+= 2.18.0 =
+* Map labels now switch language with the voice guidance
 = 2.17.0 =
 * Satellite map default, improved navigation controls
 = 2.16.0 =


### PR DESCRIPTION
## Summary
- load Mapbox language plugin
- tie map labels and voice guidance to the selected language
- document new language feature
- bump version to 2.18.0

## Testing
- `git commit -m "Add language control"`

------
https://chatgpt.com/codex/tasks/task_e_684f4266265483278d0d8d183bdd0ae7