### PR TITLE
Remove Στρουμπί and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.18.1
+- Removed Στρουμπί from the default locations dataset
 ### 2.18.0
 - Map labels switch languages along with voice instructions
 ### 2.17.0

--- a/data/locations.json
+++ b/data/locations.json
@@ -1,5 +1,4 @@
 [
-  {"title": "\u03a3\u03c4\u03c1\u03bf\u03c5\u03bc\u03c0\u03af", "content": "", "image": null, "gallery": [], "lat": 34.884028, "lng": 32.480806},
   {"title": "\u039c\u03bf\u03c5\u03c3\u03b5\u03af\u03bf \u0391\u03b3\u03c1\u03bf\u03c4\u03b9\u03ba\u03ae\u03c2 \u0396\u03ce\u03b7\u03c2 \u0391\u03ba\u03ac\u03bc\u03b1 - \u039a\u03bf\u03b9\u03bd\u03bf\u03c4\u03b9\u03ba\u03cc \u03a3\u03c5\u03bc\u03b2\u03bf\u03cd\u03bb\u03b9\u03bf \u0394\u03c1\u03bf\u03cd\u03c3\u03b5\u03b9\u03b1\u03c2", "content": "", "image": null, "gallery": [], "lat": 34.959863, "lng": 32.397797},
   {"title": "\u03a0\u03ad\u03c4\u03c1\u03b1 \u03c4\u03bf\u03c5 \u039d\u03b9\u03ba\u03bf\u03bb\u03ac", "content": "", "image": null, "gallery": [], "lat": 34.967306, "lng": 32.394056},
   {"title": "\u03a0\u03ad\u03c4\u03c1\u03b1 \u03b7 \u039b\u03ac\u03bc\u03b9\u03b1", "content": "", "image": null, "gallery": [], "lat": 34.969667, "lng": 32.391861},

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.18.0
+Version: 2.18.1
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.18.0
+Stable tag: 2.18.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -36,6 +36,8 @@ GN Mapbox Locations with ACF creates a **Map Location** post type for storing co
 Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose logs to the browser console.
 
 == Changelog ==
+= 2.18.1 =
+* Removed Στρουμπί from the default locations dataset
 = 2.18.0 =
 * Map labels now switch language with the voice guidance
 = 2.17.0 =


### PR DESCRIPTION
## Summary
- remove Στρουμπί from `locations.json`
- bump plugin version to 2.18.1
- update changelog entries

## Testing
- `python3 -m json.tool data/locations.json`

------
https://chatgpt.com/codex/tasks/task_e_68506c0607708327af7636db6b888cd8