### PR TITLE
Update version and debug notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ After visitors submit photos, they appear under **Media → Photo Approvals** in
 
 ## Debugging
 Enable the **Debug Panel** setting under **Settings → GN Mapbox** to output detailed logs to the browser console and on-screen panel.
+Markers are logged in the order they appear in `data/locations.json`.
 
 ## Offline Caching
 A service worker caches Mapbox tiles for offline use once a page has been loaded online. The map will then continue working with the cached tiles when the network is unavailable.
@@ -43,6 +44,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.18.3
+- Document debug log order for points of interest
 ### 2.18.2
 - Default route now returns to the starting point
 ### 2.18.1

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.18.2
+Version: 2.18.3
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.18.2
+Stable tag: 2.18.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -34,8 +34,11 @@ GN Mapbox Locations with ACF creates a **Map Location** post type for storing co
 
 == Debugging ==
 Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose logs to the browser console.
+Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.18.3 =
+- No code changes; version bump and documentation on debug log order of points of interest
 = 2.18.2 =
 * Default route now returns to the starting point
 = 2.18.1 =


### PR DESCRIPTION
## Summary
- bump plugin version to 2.18.3
- document the order of logged markers in the debug panel

## Testing
- `php -l gn-mapbox-plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_68507318795083278661d926e9e61ded