### PR TITLE
Add video upload approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@
 This WordPress plugin displays custom post type locations on a Mapbox map. It allows visitors to view markers, follow routes and even get spoken navigation.
 
 ## Features
-- "Map Location" custom post type stores coordinates, descriptions and unlimited gallery images.
+ - "Map Location" custom post type stores coordinates, descriptions and unlimited gallery media.
 - `[gn_map]` shortcode embeds a fully interactive Mapbox map anywhere on your site.
-- Responsive popups display images, descriptions and photo upload forms.
-- Gallery and featured images open in a lightbox that scales beautifully on all devices.
+ - Responsive popups display images, descriptions and media upload forms.
+ - Gallery items open in a lightbox that scales beautifully on all devices.
 - Draggable navigation panel offers driving, walking and cycling directions with voice guidance.
 - Map labels and voice guidance follow the selected language.
 - Spoken instructions use the browser speech API and can be muted or unmuted at any time.
 - Animated route line with optional elevation graph and real-time statistics.
 - On-screen debug panel and console logs when debugging is enabled.
 - Service worker caches Mapbox tiles so viewed maps continue working offline.
-- Visitors can upload photos from the front end; admins can approve or delete submissions before publishing.
+- Visitors can upload photos or videos from the front end; admins can approve or delete submissions before publishing.
 - Upload forms automatically appear in map popups and inside each location post.
 - Example locations from `data/locations.json` are imported if none exist.
 - Built-in update checker fetches new versions directly from GitHub.
@@ -27,8 +27,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
-## Approving Uploaded Photos
-After visitors submit photos, they appear under **Media → Photo Approvals** in the WordPress admin. Review each image and either **Approve** it to publish in the location gallery or **Delete** it permanently.
+## Approving Uploaded Media
+After visitors submit photos or videos, they appear under **Media → Photo Approvals** in the WordPress admin. Review each item and either **Approve** it to publish in the location gallery or **Delete** it permanently.
 
 ## Debugging
 Enable the **Debug Panel** setting under **Settings → GN Mapbox** to output detailed logs to the browser console and on-screen panel.
@@ -44,6 +44,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.19.0
+- Video uploads now supported with approval and deletion
 ### 2.18.5
 - Pending photo approval screen now includes a Delete option
 ### 2.18.4

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -58,7 +58,7 @@
   border-radius: 6px !important;
 }
 
-/* Optional image gallery */
+/* Optional media gallery */
 #gn-mapbox-map .popup-content .gallery {
   display: flex !important;
   flex-wrap: wrap !important;
@@ -66,7 +66,8 @@
   margin-top: 15px !important;
 }
 
-#gn-mapbox-map .popup-content .gallery img {
+#gn-mapbox-map .popup-content .gallery img,
+#gn-mapbox-map .popup-content .gallery video {
   width: 48% !important;
   height: auto !important;
   border-radius: 4px !important;

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -419,7 +419,13 @@ document.addEventListener("DOMContentLoaded", function () {
     gnMapData.locations.forEach((loc) => {
       const galleryHTML = loc.gallery && loc.gallery.length
         ? '<div class="gallery">' +
-          loc.gallery.map(url => `<img src="${url}" alt="${loc.title}">`).join('') +
+          loc.gallery
+            .map(item =>
+              item.type === 'video'
+                ? `<video src="${item.url}" controls></video>`
+                : `<img src="${item.url}" alt="${loc.title}">`
+            )
+            .join('') +
           '</div>'
         : '';
       const uploadHTML = loc.upload_form ? `<div class="gn-upload-form">${loc.upload_form}</div>` : '';

--- a/readme.txt
+++ b/readme.txt
@@ -3,25 +3,25 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.18.5
+Stable tag: 2.19.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Display custom map locations on a Mapbox-powered map complete with voice guided navigation, animated routes, offline caching and photo galleries.
+Display custom map locations on a Mapbox-powered map complete with voice guided navigation, animated routes, offline caching and media galleries.
 
 == Description ==
-GN Mapbox Locations with ACF creates a **Map Location** post type for storing coordinates, descriptions and images. Place the `[gn_map]` shortcode anywhere to display an interactive map. A draggable navigation panel gives visitors driving, walking or cycling directions with spoken instructions that can be muted. Routes can be animated and paused or resumed, while a service worker caches tiles for offline use. A debug panel outputs verbose logs when enabled. Visitors can submit photos from the front end which administrators approve before publishing. Example locations are automatically imported if none exist.
+GN Mapbox Locations with ACF creates a **Map Location** post type for storing coordinates, descriptions and images. Place the `[gn_map]` shortcode anywhere to display an interactive map. A draggable navigation panel gives visitors driving, walking or cycling directions with spoken instructions that can be muted. Routes can be animated and paused or resumed, while a service worker caches tiles for offline use. A debug panel outputs verbose logs when enabled. Visitors can submit photos or videos from the front end which administrators approve before publishing. Example locations are automatically imported if none exist.
 == Features ==
 * "Map Location" custom post type storing coordinates, descriptions and galleries.
 * `[gn_map]` shortcode embeds an interactive Mapbox map anywhere.
-* Responsive popups show images, descriptions and an upload form.
-* Gallery and featured images open in a lightbox and scale to any screen.
+* Responsive popups show images, descriptions and a media upload form.
+* Gallery items open in a lightbox and scale to any screen.
 * Draggable navigation panel for driving, walking or cycling directions with voice guidance.
 * Voice instructions can be muted or unmuted and support multiple languages.
 * Animated route line with optional elevation graph and statistics.
 * Debug panel outputs verbose logs on screen and to the browser console.
 * Offline map tile caching via service worker.
-* Visitors may upload photos on the front end; admins can approve or delete each submission before publishing.
+* Visitors may upload photos or videos on the front end; admins can approve or delete each submission before publishing.
 * Upload forms automatically appear in map popups and inside each location post.
 * Example locations from `data/locations.json` are imported when none exist.
 * Automatic update checks from GitHub.
@@ -37,6 +37,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.19.0 =
+* Video uploads supported with approval and deletion
 = 2.18.5 =
 * Pending photo approval screen now allows deletion of images
 = 2.18.4 =


### PR DESCRIPTION
## Summary
- enable video uploads with admin approval and deletion
- show video previews alongside photos
- display videos in galleries
- style gallery for videos and images
- document media uploads and bump version to 2.19.0

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685096c2ed1c83278ad3daa9051beebd