### PR TITLE
Implement direct route drawing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.20.0
+- Route drawn directly from provided coordinates
 ### 2.19.0
 - Video uploads now supported with approval and deletion
 ### 2.18.5

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.19.0
+Version: 2.20.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -445,23 +445,29 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     if (coords.length > 1) {
-      const pairs = coords.map(c => c.join(',')).join(';');
-      const url = `https://api.mapbox.com/directions/v5/mapbox/driving/${pairs}?geometries=geojson&overview=full&access_token=${mapboxgl.accessToken}`;
-      fetch(url)
-        .then(r => r.json())
-        .then(data => {
-          if (data.routes && data.routes[0]) {
-            map.addSource('route', { type: 'geojson', data: { type: 'Feature', geometry: data.routes[0].geometry } });
-            map.addLayer({
-              id: 'route',
-              type: 'line',
-              source: 'route',
-              layout: { 'line-join': 'round', 'line-cap': 'round' },
-              paint: { 'line-color': '#ff0000', 'line-width': 4 }
-            });
-            log('Route loaded from Directions API');
-          }
-        });
+      coords.forEach((point, idx) => {
+        if (idx > 0) {
+          log('Route segment', coords[idx - 1], '->', point);
+        }
+      });
+
+      const routeGeoJson = {
+        type: 'Feature',
+        geometry: {
+          type: 'LineString',
+          coordinates: coords
+        }
+      };
+
+      map.addSource('route', { type: 'geojson', data: routeGeoJson });
+      map.addLayer({
+        id: 'route',
+        type: 'line',
+        source: 'route',
+        layout: { 'line-join': 'round', 'line-cap': 'round' },
+        paint: { 'line-color': '#ff0000', 'line-width': 4 }
+      });
+      log('Route drawn using provided coordinates:', coords);
     }
   });
   });

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.19.0
+Stable tag: 2.20.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.20.0 =
+* Route drawn directly from provided coordinates
 = 2.19.0 =
 * Video uploads supported with approval and deletion
 = 2.18.5 =


### PR DESCRIPTION
## Summary
- draw routes using provided coordinates instead of Directions API
- bump plugin version to 2.20.0
- document new version

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68518f8b5a408327bbb050e1296edd2f