### PR TITLE
Implement invisible waypoints feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.22.0
+- Invisible waypoints supported for road-following routes
 ### 2.21.0
 - Directions API uses ordered coordinates and displays elevation gain
 ### 2.20.0

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -469,10 +469,14 @@ document.addEventListener("DOMContentLoaded", function () {
           ${uploadHTML}
         </div>
       `;
-      const popup = new mapboxgl.Popup({ offset: 25 }).setHTML(popupHTML);
-      new mapboxgl.Marker().setLngLat([loc.lng, loc.lat]).setPopup(popup).addTo(map);
       coords.push([loc.lng, loc.lat]);
-      log("Marker added:", loc.title, [loc.lng, loc.lat]);
+      if (!loc.waypoint) {
+        const popup = new mapboxgl.Popup({ offset: 25 }).setHTML(popupHTML);
+        new mapboxgl.Marker().setLngLat([loc.lng, loc.lat]).setPopup(popup).addTo(map);
+        log("Marker added:", loc.title, [loc.lng, loc.lat]);
+      } else {
+        log("Waypoint added:", loc.title, [loc.lng, loc.lat]);
+      }
     });
 
     if (coords.length > 1) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.21.0
+Stable tag: 2.22.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.22.0 =
+* Invisible waypoints supported for road-following routes
 = 2.21.0 =
 * Directions API uses ordered coordinates and shows elevation gain
 = 2.20.0 =


### PR DESCRIPTION
## Summary
- bump plugin version to 2.22.0
- add invisible waypoint support via post meta
- include waypoint data when importing defaults or reading JSON
- skip marker rendering for invisible waypoints in JS
- document new feature in changelog

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685196ed7e8c8327b353dd9e1006fb14