### PR TITLE
Bump plugin version to 2.22.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.22.1
+- Fix route guidance for nature walks and rides
 ### 2.22.0
 - Invisible waypoints supported for road-following routes
 ### 2.21.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.22.0
+Version: 2.22.1
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.22.0
+Stable tag: 2.22.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.22.1 =
+* Fix route guidance for nature walks and rides
 = 2.22.0 =
 * Invisible waypoints supported for road-following routes
 = 2.21.0 =


### PR DESCRIPTION
## Summary
- bump plugin version to 2.22.1
- document bug fix in changelog

## Testing
- `npm test` *(fails: could not find package.json)*
- `php -l gn-mapbox-plugin.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68519a5a04848327ab32cb4d8b8d0d74