### PR TITLE
Add quick edit position support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.24.0
+- Position can now be edited from Quick Edit
 ### 2.23.0
 - Locations can be ordered using a Position field and displayed in the admin list
 ### 2.22.1

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.23.0
+Stable tag: 2.24.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.24.0 =
+* Position field can now be edited from Quick Edit
 = 2.23.0 =
 * Locations can be ordered using a Position field
 * Position number displayed in the Map Location list


### PR DESCRIPTION
## Summary
- add position field to Quick Edit screen
- bump plugin version to 2.24.0
- document Quick Edit support

## Testing
- `php -l gn-mapbox-plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_68519eab9608832792ed873d127f5d80