### PR TITLE
Bump plugin version to 2.24.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.24.3
+- No code changes; version bump
 ### 2.24.1
 - Updated default location dataset with invisible waypoints
 ### 2.24.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.24.2
+Version: 2.24.3
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.24.2
+Stable tag: 2.24.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.24.3 =
+* No code changes; version bump
 = 2.24.2 =
 * Removed numbers from visible location names
 = 2.24.1 =


### PR DESCRIPTION
## Summary
- bump version to 2.24.3
- document version bump in readme files

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851cd3a0a4c8327b8d260c78414f265