### PR TITLE
Add new village map shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 - Visitors can upload photos or videos from the front end; admins can approve or delete submissions before publishing.
 - Upload forms automatically appear in map popups and inside each location post.
 - Example locations from `data/locations.json` are imported if none exist.
+- `[gn_village_map]` shortcode shows the Drouseia boundary with hotels, taverns and villas.
 - Built-in update checker fetches new versions directly from GitHub.
 - Ready for translation and WPML compatible.
 
@@ -25,7 +26,7 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 3. Enter your Mapbox access token in **Settings → GN Mapbox**.
 
 ## Usage
-Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page. Use `[gn_village_map]` to show the Drouseia village boundary with hotels, taverns and villas marked.
 
 ## Approving Uploaded Media
 After visitors submit photos or videos, they appear under **Media → Photo Approvals** in the WordPress admin. Review each item and either **Approve** it to publish in the location gallery or **Delete** it permanently.
@@ -44,6 +45,11 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.25.0
+- Added `[gn_village_map]` shortcode for viewing the village boundary and points of interest
+- Custom icons show hotels, taverns and villas with names in Greek and English
+- Zoom controls enabled for full interactivity
+
 ### 2.24.3
 - No code changes; version bump
 ### 2.24.1

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -214,3 +214,7 @@
   font-size: 32px;
   cursor: pointer;
 }
+.drouseia-marker {
+  width: 32px;
+  height: 32px;
+}

--- a/data/village.json
+++ b/data/village.json
@@ -1,0 +1,33 @@
+{
+  "boundary": [
+    [32.392, 34.969],
+    [32.399, 34.976],
+    [32.406, 34.969],
+    [32.406, 34.959],
+    [32.392, 34.959],
+    [32.392, 34.969]
+  ],
+  "places": [
+    {
+      "type": "hotel",
+      "title_el": "\u039E\u03b5\u03bd\u03bf\u03b4\u03bf\u03c7\u03b5\u03af\u03bf \u0391\u03ba\u03ac\u03bc\u03b1\u03c2",
+      "title_en": "Akamas Hotel",
+      "lat": 34.962,
+      "lng": 32.398
+    },
+    {
+      "type": "tavern",
+      "title_el": "\u03a4\u03b1\u03b2\u03ad\u03c1\u03bd\u03b1 \u03a7\u03c9\u03c1\u03b9\u03bf\u03cd",
+      "title_en": "Village Tavern",
+      "lat": 34.961,
+      "lng": 32.397
+    },
+    {
+      "type": "villa",
+      "title_el": "\u0392\u03af\u03bb\u03b1 \u0394\u03c1\u03bf\u03cd\u03c3\u03b5\u03b9\u03b1",
+      "title_en": "Drouseia Villa",
+      "lat": 34.964,
+      "lng": 32.401
+    }
+  ]
+}

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.24.3
+Version: 2.25.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -333,6 +333,7 @@ function gn_enqueue_mapbox_assets() {
     wp_enqueue_script('gn-mapbox-init', plugin_dir_url(__FILE__) . 'js/mapbox-init.js', ['jquery', 'mapbox-gl-language'], null, true);
     wp_enqueue_script('gn-sw-register', plugin_dir_url(__FILE__) . 'js/sw-register.js', [], null, true);
     wp_enqueue_script('gn-photo-upload', plugin_dir_url(__FILE__) . 'js/gn-photo-upload.js', ['jquery'], null, true);
+    wp_enqueue_script('gn-village-map', plugin_dir_url(__FILE__) . 'js/gn-village-map.js', ['mapbox-gl'], null, true);
 
     wp_localize_script('gn-mapbox-init', 'gnMapData', [
         'accessToken' => get_option('gn_mapbox_token'),
@@ -346,6 +347,17 @@ function gn_enqueue_mapbox_assets() {
     wp_localize_script('gn-mapbox-init', 'gnPhotoStrings', [
         'select_photos' => __('Select Photos', 'gn-mapbox'),
         'use_photos'    => __('Use these photos', 'gn-mapbox')
+    ]);
+    $village = gn_get_village_data();
+    wp_localize_script('gn-village-map', 'gnVillageData', [
+        'accessToken' => get_option('gn_mapbox_token'),
+        'boundary'    => $village['boundary'],
+        'places'      => $village['places'],
+        'icons'       => [
+            'hotel'  => plugin_dir_url(__FILE__) . 'icons/hotel.svg',
+            'tavern' => plugin_dir_url(__FILE__) . 'icons/tavern.svg',
+            'villa'  => plugin_dir_url(__FILE__) . 'icons/villa.svg',
+        ],
     ]);
 }
 add_action('wp_enqueue_scripts', 'gn_enqueue_mapbox_assets');
@@ -731,4 +743,21 @@ function gn_process_photo_deletion() {
     exit;
 }
 add_action('admin_post_gn_delete_photo', 'gn_process_photo_deletion');
+
+function gn_get_village_data() {
+    $json_file = plugin_dir_path(__FILE__) . 'data/village.json';
+    if (file_exists($json_file)) {
+        $json = file_get_contents($json_file);
+        $data = json_decode($json, true);
+        if (is_array($data)) {
+            return $data;
+        }
+    }
+    return ['boundary' => [], 'places' => []];
+}
+
+function gn_village_map_shortcode() {
+    return '<div id="gn-village-map" style="width:100%;height:600px;"></div>';
+}
+add_shortcode('gn_village_map', 'gn_village_map_shortcode');
 

--- a/icons/hotel.svg
+++ b/icons/hotel.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M2 15h20v6H2z" fill="#d4d4d4" stroke="#000"/>
+  <path d="M6 9h12v6H6z" fill="#fff" stroke="#000"/>
+  <path d="M3 21v-9M21 21v-9" stroke="#000" fill="none"/>
+</svg>

--- a/icons/tavern.svg
+++ b/icons/tavern.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M4 4h16v7a6 6 0 0 1-6 6H10a6 6 0 0 1-6-6V4z" fill="#fff" stroke="#000"/>
+  <path d="M9 21h6" stroke="#000"/>
+</svg>

--- a/icons/villa.svg
+++ b/icons/villa.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M3 11l9-8 9 8v10H3z" fill="#fff" stroke="#000"/>
+  <path d="M9 21V12h6v9" fill="none" stroke="#000"/>
+</svg>

--- a/js/gn-village-map.js
+++ b/js/gn-village-map.js
@@ -1,0 +1,46 @@
+document.addEventListener('DOMContentLoaded', function() {
+  if (!document.getElementById('gn-village-map')) return;
+
+  mapboxgl.accessToken = gnVillageData.accessToken;
+  const map = new mapboxgl.Map({
+    container: 'gn-village-map',
+    style: 'mapbox://styles/mapbox/streets-v11',
+    center: [32.398, 34.964],
+    zoom: 15
+  });
+
+  map.addControl(new mapboxgl.NavigationControl(), 'top-right');
+
+  map.on('load', () => {
+    map.addSource('village-boundary', {
+      type: 'geojson',
+      data: {
+        type: 'Feature',
+        geometry: {
+          type: 'Polygon',
+          coordinates: [gnVillageData.boundary]
+        }
+      }
+    });
+
+    map.addLayer({
+      id: 'village-boundary',
+      type: 'line',
+      source: 'village-boundary',
+      paint: {
+        'line-color': '#000',
+        'line-width': 2,
+        'line-dasharray': [2, 2]
+      }
+    });
+
+    gnVillageData.places.forEach(place => {
+      const el = document.createElement('img');
+      el.src = gnVillageData.icons[place.type];
+      el.className = 'drouseia-marker';
+      const popup = new mapboxgl.Popup({ offset: 25 })
+        .setHTML(`<strong>${place.title_el}</strong><br>${place.title_en}`);
+      new mapboxgl.Marker(el).setLngLat([place.lng, place.lat]).setPopup(popup).addTo(map);
+    });
+  });
+});

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.24.3
+Stable tag: 2.25.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -11,6 +11,8 @@ Display custom map locations on a Mapbox-powered map complete with voice guided 
 
 == Description ==
 GN Mapbox Locations with ACF creates a **Map Location** post type for storing coordinates, descriptions and images. Place the `[gn_map]` shortcode anywhere to display an interactive map. A draggable navigation panel gives visitors driving, walking or cycling directions with spoken instructions that can be muted. Routes can be animated and paused or resumed, while a service worker caches tiles for offline use. A debug panel outputs verbose logs when enabled. Visitors can submit photos or videos from the front end which administrators approve before publishing. Example locations are automatically imported if none exist.
+
+Use the `[gn_village_map]` shortcode to display the boundary of Drouseia village with labeled markers for hotels, taverns and villas.
 == Features ==
 * "Map Location" custom post type storing coordinates, descriptions and galleries.
 * `[gn_map]` shortcode embeds an interactive Mapbox map anywhere.
@@ -26,6 +28,7 @@ GN Mapbox Locations with ACF creates a **Map Location** post type for storing co
 * Example locations from `data/locations.json` are imported when none exist.
 * Automatic update checks from GitHub.
 * Ready for translation and WPML compatible.
+* `[gn_village_map]` shortcode displays the village boundary with labeled points of interest.
 
 == Installation ==
 1. Upload the plugin folder to `/wp-content/plugins/`.
@@ -37,6 +40,10 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.25.0 =
+* Added `[gn_village_map]` shortcode displaying Drouseia boundary and labelled markers
+* Custom icons or Maki symbols show hotels, taverns and villas in Greek and English
+* Zoom controls allow full interactivity
 = 2.24.3 =
 * No code changes; version bump
 = 2.24.2 =


### PR DESCRIPTION
## Summary
- create a new `[gn_village_map]` shortcode
- load village boundary/markers dataset
- add custom marker icons
- support new JS map initialization
- bump plugin version to 2.25.0
- document new shortcode in README and readme.txt

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854449d62208327b97f76657ec64cf3