### PR TITLE
Update gn_village_map to show only boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 - Visitors can upload photos or videos from the front end; admins can approve or delete submissions before publishing.
 - Upload forms automatically appear in map popups and inside each location post.
 - Example locations from `data/locations.json` are imported if none exist.
-- `[gn_village_map]` shortcode shows the Drouseia boundary with hotels, taverns and villas.
+- `[gn_village_map]` shortcode shows only the Drouseia village boundary.
 - Built-in update checker fetches new versions directly from GitHub.
 - Ready for translation and WPML compatible.
 
@@ -26,7 +26,7 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 3. Enter your Mapbox access token in **Settings → GN Mapbox**.
 
 ## Usage
-Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page. Use `[gn_village_map]` to show the Drouseia village boundary with hotels, taverns and villas marked.
+Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page. Use `[gn_village_map]` to show just the Drouseia village boundary.
 
 ## Approving Uploaded Media
 After visitors submit photos or videos, they appear under **Media → Photo Approvals** in the WordPress admin. Review each item and either **Approve** it to publish in the location gallery or **Delete** it permanently.
@@ -45,6 +45,9 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.26.0
+- `[gn_village_map]` shortcode now displays only the village boundary
+
 ### 2.25.0
 - Added `[gn_village_map]` shortcode for viewing the village boundary and points of interest
 - Custom icons show hotels, taverns and villas with names in Greek and English

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.25.0
+Version: 2.26.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/gn-village-map.js
+++ b/js/gn-village-map.js
@@ -34,13 +34,5 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     });
 
-    gnVillageData.places.forEach(place => {
-      const el = document.createElement('img');
-      el.src = gnVillageData.icons[place.type];
-      el.className = 'drouseia-marker';
-      const popup = new mapboxgl.Popup({ offset: 25 })
-        .setHTML(`<strong>${place.title_el}</strong><br>${place.title_en}`);
-      new mapboxgl.Marker(el).setLngLat([place.lng, place.lat]).setPopup(popup).addTo(map);
-    });
   });
 });

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.25.0
+Stable tag: 2.26.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,7 +12,7 @@ Display custom map locations on a Mapbox-powered map complete with voice guided 
 == Description ==
 GN Mapbox Locations with ACF creates a **Map Location** post type for storing coordinates, descriptions and images. Place the `[gn_map]` shortcode anywhere to display an interactive map. A draggable navigation panel gives visitors driving, walking or cycling directions with spoken instructions that can be muted. Routes can be animated and paused or resumed, while a service worker caches tiles for offline use. A debug panel outputs verbose logs when enabled. Visitors can submit photos or videos from the front end which administrators approve before publishing. Example locations are automatically imported if none exist.
 
-Use the `[gn_village_map]` shortcode to display the boundary of Drouseia village with labeled markers for hotels, taverns and villas.
+Use the `[gn_village_map]` shortcode to display only the boundary of Drouseia village.
 == Features ==
 * "Map Location" custom post type storing coordinates, descriptions and galleries.
 * `[gn_map]` shortcode embeds an interactive Mapbox map anywhere.
@@ -28,7 +28,7 @@ Use the `[gn_village_map]` shortcode to display the boundary of Drouseia village
 * Example locations from `data/locations.json` are imported when none exist.
 * Automatic update checks from GitHub.
 * Ready for translation and WPML compatible.
-* `[gn_village_map]` shortcode displays the village boundary with labeled points of interest.
+* `[gn_village_map]` shortcode displays only the village boundary.
 
 == Installation ==
 1. Upload the plugin folder to `/wp-content/plugins/`.
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.26.0 =
+* `[gn_village_map]` shortcode now displays only the village boundary
+
 = 2.25.0 =
 * Added `[gn_village_map]` shortcode displaying Drouseia boundary and labelled markers
 * Custom icons or Maki symbols show hotels, taverns and villas in Greek and English


### PR DESCRIPTION
## Summary
- hide POI markers in `gn_village_map`
- document change and bump plugin version to 2.26.0

## Testing
- *(failed: `php -l gn-mapbox-plugin.php` - `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685446b903748327adc1ba27a5d797bb