### PR TITLE
Handle large routes by chunking Directions API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.29.0
+- Support more than 25 coordinates by chunking Directions API requests
 ### 2.28.0
 - Default route now follows the road using Mapbox Directions API
 ### 2.27.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.28.0
+Version: 2.29.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.28.0
+Stable tag: 2.29.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -38,6 +38,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.29.0 =
+* Support more than 25 coordinates by chunking Directions API requests
 = 2.28.0 =
 * Default route now follows the road using Mapbox Directions API
 


### PR DESCRIPTION
## Summary
- chunk Directions API calls into segments of 25 coordinates
- update navigation logic to use new helper
- bump plugin version to 2.29.0 and document changes

## Testing
- `node --check js/mapbox-init.js`

------
https://chatgpt.com/codex/tasks/task_e_6856ee2cfcbc83278eedeaea56c5c852