### PR TITLE
Add Drouseia map shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Features
  - "Map Location" custom post type stores coordinates, descriptions and unlimited gallery media.
 - `[gn_map]` shortcode embeds a fully interactive Mapbox map anywhere on your site.
+- `[gn_mapbox_drouseia]` shortcode shows a simple map centered on Drouseia.
  - Responsive popups display images, descriptions and media upload forms.
  - Gallery items open in a lightbox that scales beautifully on all devices.
 - Draggable navigation panel offers driving, walking and cycling directions with voice guidance.
@@ -26,6 +27,7 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+Use the `[gn_mapbox_drouseia]` shortcode to show a standalone map centered on Drouseia.
 
 ## Approving Uploaded Media
 After visitors submit photos or videos, they appear under **Media → Photo Approvals** in the WordPress admin. Review each item and either **Approve** it to publish in the location gallery or **Delete** it permanently.
@@ -44,6 +46,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.30.0
+- Added `[gn_mapbox_drouseia]` shortcode for a simple map of Drouseia
 ### 2.29.0
 - Support more than 25 coordinates by chunking Directions API requests
 ### 2.28.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.29.0
+Version: 2.30.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -730,6 +730,36 @@ function gn_process_photo_deletion() {
     exit;
 }
 add_action('admin_post_gn_delete_photo', 'gn_process_photo_deletion');
+
+/**
+ * Simple shortcode displaying a single marker on Drouseia using Mapbox GL JS.
+ * Usage: [gn_mapbox_drouseia]
+ */
+function gn_mapbox_drouseia_shortcode() {
+    $token = get_option('gn_mapbox_token');
+    ob_start();
+    ?>
+    <div id="gn-mapbox-drouseia" style="width: 100%; height: 400px;"></div>
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
+    <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
+    <script>
+      mapboxgl.accessToken = '<?php echo esc_js($token); ?>';
+      const map = new mapboxgl.Map({
+        container: 'gn-mapbox-drouseia',
+        style: 'mapbox://styles/mapbox/streets-v11',
+        center: [32.3975751, 34.9627965],
+        zoom: 14
+      });
+
+      new mapboxgl.Marker()
+        .setLngLat([32.3975751, 34.9627965])
+        .setPopup(new mapboxgl.Popup().setText('Drouseia, Cyprus'))
+        .addTo(map);
+    </script>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode('gn_mapbox_drouseia', 'gn_mapbox_drouseia_shortcode');
 
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.29.0
+Stable tag: 2.30.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -15,6 +15,7 @@ GN Mapbox Locations with ACF creates a **Map Location** post type for storing co
 == Features ==
 * "Map Location" custom post type storing coordinates, descriptions and galleries.
 * `[gn_map]` shortcode embeds an interactive Mapbox map anywhere.
+* `[gn_mapbox_drouseia]` shortcode displays a simple map centered on Drouseia.
 * Responsive popups show images, descriptions and a media upload form.
 * Gallery items open in a lightbox and scale to any screen.
 * Draggable navigation panel for driving, walking or cycling directions with voice guidance.
@@ -38,6 +39,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.30.0 =
+* Added `[gn_mapbox_drouseia]` shortcode displaying a simple map of Drouseia
 = 2.29.0 =
 * Support more than 25 coordinates by chunking Directions API requests
 = 2.28.0 =


### PR DESCRIPTION
## Summary
- add `[gn_mapbox_drouseia]` shortcode for a simple Mapbox map
- bump plugin version to 2.30.0
- document new shortcode and update changelogs

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858238e7be48327a9928e34b4b88c27