### PR TITLE
Expand Drouseia circle and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Features
  - "Map Location" custom post type stores coordinates, descriptions and unlimited gallery media.
 - `[gn_map]` shortcode embeds a fully interactive Mapbox map anywhere on your site.
-- `[gn_mapbox_drouseia]` shortcode shows Drouseia with a marker and smooth red boundary line.
+- `[gn_mapbox_drouseia]` shortcode shows Drouseia with a marker and wide circular red boundary line.
  - Responsive popups display images, descriptions and media upload forms.
  - Gallery items open in a lightbox that scales beautifully on all devices.
 - Draggable navigation panel offers driving, walking and cycling directions with voice guidance.
@@ -28,6 +28,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.35.0
+- Wider circular boundary and zoom level adjusted on `[gn_mapbox_drouseia]`
 ### 2.34.0
 - `[gn_mapbox_drouseia]` boundary line is now drawn as a smooth circle
 ### 2.33.0
@@ -51,6 +53,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.35.0
+- Wider boundary circle and adjusted zoom on `[gn_mapbox_drouseia]`
 ### 2.34.0
 - More circular boundary line on `[gn_mapbox_drouseia]` map
 ### 2.32.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.34.0
+Version: 2.35.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -733,7 +733,7 @@ add_action('admin_post_gn_delete_photo', 'gn_process_photo_deletion');
 
 /**
  * Simple shortcode displaying a single marker on Drouseia using Mapbox GL JS.
- * The map also outlines the village with a circular red boundary line.
+ * The map also outlines the village with a wider circular red boundary line.
  * Usage: [gn_mapbox_drouseia]
 */
 function gn_mapbox_drouseia_shortcode() {
@@ -749,7 +749,7 @@ function gn_mapbox_drouseia_shortcode() {
         container: 'gn-mapbox-drouseia',
         style: 'mapbox://styles/mapbox/streets-v11',
         center: [32.3975751, 34.9627965],
-        zoom: 14
+        zoom: 13
       });
 
       new mapboxgl.Marker()
@@ -759,7 +759,7 @@ function gn_mapbox_drouseia_shortcode() {
 
       map.on('load', () => {
         const center = [32.3975751, 34.9627965];
-        const radius = 0.003;
+        const radius = 0.005;
         const steps = 64;
         const circle = [];
         for (let i = 0; i <= steps; i++) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.34.0
+Stable tag: 2.35.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -15,7 +15,7 @@ GN Mapbox Locations with ACF creates a **Map Location** post type for storing co
 == Features ==
 * "Map Location" custom post type storing coordinates, descriptions and galleries.
 * `[gn_map]` shortcode embeds an interactive Mapbox map anywhere.
-* `[gn_mapbox_drouseia]` shortcode displays a map of Drouseia with a marker and smooth red boundary line.
+* `[gn_mapbox_drouseia]` shortcode displays a map of Drouseia with a marker and wide circular red boundary line.
 * Responsive popups show images, descriptions and a media upload form.
 * Gallery items open in a lightbox and scale to any screen.
 * Draggable navigation panel for driving, walking or cycling directions with voice guidance.
@@ -39,6 +39,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.35.0 =
+* Wider circular boundary on `[gn_mapbox_drouseia]` map and adjusted zoom
 = 2.34.0 =
 * Boundary line on `[gn_mapbox_drouseia]` is now circular
 = 2.33.0 =


### PR DESCRIPTION
## Summary
- widen the circular boundary for `[gn_mapbox_drouseia]`
- adjust zoom level for a broader view
- update plugin, readme, and changelog for version 2.35.0

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582c63eee08327909de60cbbd73186