### PR TITLE
Update Drouseia map shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Features
  - "Map Location" custom post type stores coordinates, descriptions and unlimited gallery media.
 - `[gn_map]` shortcode embeds a fully interactive Mapbox map anywhere on your site.
-- `[gn_mapbox_drouseia]` shortcode shows Drouseia with a marker and wide circular red boundary line.
+- `[gn_mapbox_drouseia]` shortcode shows Drouseia with a marker and smooth circular red boundary line.
  - Responsive popups display images, descriptions and media upload forms.
  - Gallery items open in a lightbox that scales beautifully on all devices.
 - Draggable navigation panel offers driving, walking and cycling directions with voice guidance.
@@ -28,6 +28,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.36.0
+- `[gn_mapbox_drouseia]` uses updated coordinates and smoother circle
 ### 2.35.0
 - Wider circular boundary and zoom level adjusted on `[gn_mapbox_drouseia]`
 ### 2.34.0
@@ -53,6 +55,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.36.0
+- Smoother circular boundary with corrected center and zoom on `[gn_mapbox_drouseia]`
 ### 2.35.0
 - Wider boundary circle and adjusted zoom on `[gn_mapbox_drouseia]`
 ### 2.34.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.35.0
+Version: 2.36.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -745,12 +745,12 @@ function gn_mapbox_drouseia_shortcode() {
     <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
     <script>
       mapboxgl.accessToken = '<?php echo esc_js($token); ?>';
-      const map = new mapboxgl.Map({
-        container: 'gn-mapbox-drouseia',
-        style: 'mapbox://styles/mapbox/streets-v11',
-        center: [32.3975751, 34.9627965],
-        zoom: 13
-      });
+        const map = new mapboxgl.Map({
+          container: 'gn-mapbox-drouseia',
+          style: 'mapbox://styles/mapbox/streets-v11',
+          center: [32.397521, 34.962136],
+          zoom: 14
+        });
 
       new mapboxgl.Marker()
         .setLngLat([32.3975751, 34.9627965])
@@ -758,14 +758,14 @@ function gn_mapbox_drouseia_shortcode() {
         .addTo(map);
 
       map.on('load', () => {
-        const center = [32.3975751, 34.9627965];
+        const markerCoords = [32.3975751, 34.9627965];
         const radius = 0.005;
-        const steps = 64;
+        const steps = 360;
         const circle = [];
         for (let i = 0; i <= steps; i++) {
           const angle = (i / steps) * Math.PI * 2;
-          const lng = center[0] + radius * Math.cos(angle);
-          const lat = center[1] + radius * Math.sin(angle);
+          const lng = markerCoords[0] + radius * Math.cos(angle);
+          const lat = markerCoords[1] + radius * Math.sin(angle);
           circle.push([lng, lat]);
         }
         map.addSource('drouseia-area', {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.35.0
+Stable tag: 2.36.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -39,6 +39,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.36.0 =
+* Smoother boundary circle with updated coordinates and zoom on `[gn_mapbox_drouseia]`
 = 2.35.0 =
 * Wider circular boundary on `[gn_mapbox_drouseia]` map and adjusted zoom
 = 2.34.0 =


### PR DESCRIPTION
## Summary
- refine `[gn_mapbox_drouseia]` map center, zoom and circle resolution
- bump version to 2.36.0
- document new version

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582e68006c8327a822a3f2e3f64346