### PR TITLE
Update Drouseia map shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.38.0
+- `[gn_mapbox_drouseia]` uses a Google-like map style, refined polygon boundary and a closer zoom
 ### 2.37.0
 - `[gn_mapbox_drouseia]` now draws a polygon boundary around the village and zooms in closer
 ### 2.36.0
@@ -57,6 +59,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.38.0
+- Navigation-day map style and improved polygon on `[gn_mapbox_drouseia]`
 ### 2.37.0
 - Polygon boundary around Drouseia with closer zoom on `[gn_mapbox_drouseia]`
 ### 2.36.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.37.0
+Version: 2.38.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -747,9 +747,9 @@ function gn_mapbox_drouseia_shortcode() {
       mapboxgl.accessToken = '<?php echo esc_js($token); ?>';
         const map = new mapboxgl.Map({
           container: 'gn-mapbox-drouseia',
-          style: 'mapbox://styles/mapbox/streets-v11',
-          center: [32.3975751, 34.9627965],
-          zoom: 15
+          style: 'mapbox://styles/mapbox/navigation-day-v1',
+          center: [32.3976, 34.9628],
+          zoom: 16
         });
 
       new mapboxgl.Marker()
@@ -765,13 +765,16 @@ function gn_mapbox_drouseia_shortcode() {
             geometry: {
               type: 'Polygon',
               coordinates: [[
-                [32.3930, 34.9650],
-                [32.3990, 34.9700],
-                [32.4050, 34.9650],
-                [32.4050, 34.9600],
-                [32.3990, 34.9550],
-                [32.3930, 34.9600],
-                [32.3930, 34.9650]
+                [32.3920, 34.9642],
+                [32.3945, 34.9670],
+                [32.3985, 34.9685],
+                [32.4025, 34.9675],
+                [32.4045, 34.9650],
+                [32.4040, 34.9605],
+                [32.4010, 34.9580],
+                [32.3960, 34.9575],
+                [32.3925, 34.9600],
+                [32.3920, 34.9642]
               ]]
             }
           }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.37.0
+Stable tag: 2.38.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -39,6 +39,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.38.0 =
+* Google-like map style and improved polygon with closer zoom on `[gn_mapbox_drouseia]`
 = 2.37.0 =
 * Polygon boundary around the village with a closer zoom on `[gn_mapbox_drouseia]`
 = 2.36.0 =


### PR DESCRIPTION
## Summary
- fine tune Drouseia shortcode polygon and zoom level
- switch to Mapbox `navigation-day-v1` style
- document new map behavior
- bump plugin version to 2.38.0

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685833b881c88327b6a12cac08683d9c