### PR TITLE
Update drouseia shortcode and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.39.0
+- `[gn_mapbox_drouseia]` zooms out four levels and centers on Drouseia
 ### 2.38.0
 - `[gn_mapbox_drouseia]` uses a Google-like map style, refined polygon boundary and a closer zoom
 ### 2.37.0
@@ -59,6 +61,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.39.0
+- Map zooms out four levels and centers on Drouseia for `[gn_mapbox_drouseia]`
 ### 2.38.0
 - Navigation-day map style and improved polygon on `[gn_mapbox_drouseia]`
 ### 2.37.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.38.0
+Version: 2.39.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -748,8 +748,8 @@ function gn_mapbox_drouseia_shortcode() {
         const map = new mapboxgl.Map({
           container: 'gn-mapbox-drouseia',
           style: 'mapbox://styles/mapbox/navigation-day-v1',
-          center: [32.3976, 34.9628],
-          zoom: 16
+          center: [32.3975751, 34.9627965],
+          zoom: 12
         });
 
       new mapboxgl.Marker()

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.38.0
+Stable tag: 2.39.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -39,6 +39,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.39.0 =
+* Map zooms out four levels and centers on Drouseia in `[gn_mapbox_drouseia]`
 = 2.38.0 =
 * Google-like map style and improved polygon with closer zoom on `[gn_mapbox_drouseia]`
 = 2.37.0 =


### PR DESCRIPTION
## Summary
- zoom out 4 levels for `[gn_mapbox_drouseia]` map and center on the village
- bump plugin version to 2.39.0
- document the new version in both READMEs

## Testing
- `php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685835b3fc188327af3fe0e1c8fd61a9