### PR TITLE
Improve Drouseia map zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
-### 2.39.0
-- `[gn_mapbox_drouseia]` zooms out four levels and centers on Drouseia
+### 2.40.0
+- `[gn_mapbox_drouseia]` zooms in two levels and centers on Drouseia
 ### 2.38.0
 - `[gn_mapbox_drouseia]` uses a Google-like map style, refined polygon boundary and a closer zoom
 ### 2.37.0
@@ -61,6 +61,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.40.0
+- Map zooms in two levels and centers on Drouseia for `[gn_mapbox_drouseia]`
 ### 2.39.0
 - Map zooms out four levels and centers on Drouseia for `[gn_mapbox_drouseia]`
 ### 2.38.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.39.0
+Version: 2.40.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -749,7 +749,7 @@ function gn_mapbox_drouseia_shortcode() {
           container: 'gn-mapbox-drouseia',
           style: 'mapbox://styles/mapbox/navigation-day-v1',
           center: [32.3975751, 34.9627965],
-          zoom: 12
+          zoom: 14
         });
 
       new mapboxgl.Marker()

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.39.0
+Stable tag: 2.40.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -39,6 +39,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.40.0 =
+* Map zooms in two levels and centers on Drouseia in `[gn_mapbox_drouseia]`
 = 2.39.0 =
 * Map zooms out four levels and centers on Drouseia in `[gn_mapbox_drouseia]`
 = 2.38.0 =


### PR DESCRIPTION
## Summary
- zoom in two levels on the Drouseia map
- bump plugin version to 2.40.0

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685836f74e0083279456bb10e62715f1