### PR TITLE
Add driving direction shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
  - "Map Location" custom post type stores coordinates, descriptions and unlimited gallery media.
 - `[gn_map]` shortcode embeds a fully interactive Mapbox map anywhere on your site.
 - `[gn_mapbox_drouseia]` shortcode shows Drouseia with a marker and red boundary line around the village.
+- `[gn_mapbox_drousia_paphos]`, `[gn_mapbox_drousia_polis]` and `[gn_mapbox_paphos_airport]` provide driving directions between popular destinations.
  - Responsive popups display images, descriptions and media upload forms.
  - Gallery items open in a lightbox that scales beautifully on all devices.
 - Draggable navigation panel offers driving, walking and cycling directions with voice guidance.
@@ -28,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.41.0
+- Driving direction shortcodes `[gn_mapbox_drousia_paphos]`, `[gn_mapbox_drousia_polis]` and `[gn_mapbox_paphos_airport]`
 ### 2.40.0
 - `[gn_mapbox_drouseia]` zooms in two levels and centers on Drouseia
 ### 2.38.0
@@ -61,6 +64,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.41.0
+- Driving direction shortcodes `[gn_mapbox_drousia_paphos]`, `[gn_mapbox_drousia_polis]` and `[gn_mapbox_paphos_airport]`
 ### 2.40.0
 - Map zooms in two levels and centers on Drouseia for `[gn_mapbox_drouseia]`
 ### 2.39.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.40.0
+Version: 2.41.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -804,6 +804,105 @@ function gn_mapbox_drouseia_shortcode() {
     return ob_get_clean();
 }
 add_shortcode('gn_mapbox_drouseia', 'gn_mapbox_drouseia_shortcode');
+
+// Drouseia to Paphos
+function gn_mapbox_drousia_to_paphos_shortcode() {
+    ob_start();
+    ?>
+    <div id="gn-mapbox-drousia-paphos" style="width:100%;height:600px;"></div>
+    <script>
+    jQuery(function(){
+        const mapDP = new mapboxgl.Map({
+            container: 'gn-mapbox-drousia-paphos',
+            style: 'mapbox://styles/mapbox/satellite-streets-v11',
+            center: [32.3975751, 34.9627965],
+            zoom: 10
+        });
+
+        const directionsDP = new MapboxDirections({
+            accessToken: gnMapData.accessToken,
+            unit: 'metric',
+            profile: 'mapbox/driving',
+            alternatives: false
+        });
+
+        mapDP.addControl(directionsDP, 'top-left');
+        mapDP.on('load', function() {
+            directionsDP.setOrigin([32.3975751, 34.9627965]);
+            directionsDP.setDestination([32.4297, 34.7753]);
+        });
+    });
+    </script>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode('gn_mapbox_drousia_paphos', 'gn_mapbox_drousia_to_paphos_shortcode');
+
+// Drouseia to Polis
+function gn_mapbox_drousia_to_polis_shortcode() {
+    ob_start();
+    ?>
+    <div id="gn-mapbox-drousia-polis" style="width:100%;height:600px;"></div>
+    <script>
+    jQuery(function(){
+        const mapDPo = new mapboxgl.Map({
+            container: 'gn-mapbox-drousia-polis',
+            style: 'mapbox://styles/mapbox/satellite-streets-v11',
+            center: [32.3975751, 34.9627965],
+            zoom: 11
+        });
+
+        const directionsDPo = new MapboxDirections({
+            accessToken: gnMapData.accessToken,
+            unit: 'metric',
+            profile: 'mapbox/driving',
+            alternatives: false
+        });
+
+        mapDPo.addControl(directionsDPo, 'top-left');
+        mapDPo.on('load', function() {
+            directionsDPo.setOrigin([32.3975751, 34.9627965]);
+            directionsDPo.setDestination([32.4147, 35.0360]);
+        });
+    });
+    </script>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode('gn_mapbox_drousia_polis', 'gn_mapbox_drousia_to_polis_shortcode');
+
+// Paphos to Paphos Airport
+function gn_mapbox_paphos_to_airport_shortcode() {
+    ob_start();
+    ?>
+    <div id="gn-mapbox-paphos-airport" style="width:100%;height:600px;"></div>
+    <script>
+    jQuery(function(){
+        const mapPA = new mapboxgl.Map({
+            container: 'gn-mapbox-paphos-airport',
+            style: 'mapbox://styles/mapbox/satellite-streets-v11',
+            center: [32.4297, 34.7753],
+            zoom: 12
+        });
+
+        const directionsPA = new MapboxDirections({
+            accessToken: gnMapData.accessToken,
+            unit: 'metric',
+            profile: 'mapbox/driving',
+            alternatives: false
+        });
+
+        mapPA.addControl(directionsPA, 'top-left');
+        mapPA.on('load', function() {
+            directionsPA.setOrigin([32.4297, 34.7753]);
+            directionsPA.setDestination([32.4858, 34.7174]);
+        });
+    });
+    </script>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode('gn_mapbox_paphos_airport', 'gn_mapbox_paphos_to_airport_shortcode');
 
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.40.0
+Stable tag: 2.41.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -16,6 +16,7 @@ GN Mapbox Locations with ACF creates a **Map Location** post type for storing co
 * "Map Location" custom post type storing coordinates, descriptions and galleries.
 * `[gn_map]` shortcode embeds an interactive Mapbox map anywhere.
 * `[gn_mapbox_drouseia]` shortcode displays a map of Drouseia with a marker and red boundary line around the village.
+* `[gn_mapbox_drousia_paphos]`, `[gn_mapbox_drousia_polis]` and `[gn_mapbox_paphos_airport]` show driving directions between key locations.
 * Responsive popups show images, descriptions and a media upload form.
 * Gallery items open in a lightbox and scale to any screen.
 * Draggable navigation panel for driving, walking or cycling directions with voice guidance.
@@ -39,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.41.0 =
+* Driving direction shortcodes `[gn_mapbox_drousia_paphos]`, `[gn_mapbox_drousia_polis]` and `[gn_mapbox_paphos_airport]`
 = 2.40.0 =
 * Map zooms in two levels and centers on Drouseia in `[gn_mapbox_drouseia]`
 = 2.39.0 =


### PR DESCRIPTION
## Summary
- add Mapbox direction shortcodes for Drouseia-Paphos, Drouseia-Polis and Paphos-Airport
- bump plugin version to 2.41.0
- document new shortcodes and update changelog

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68583c3e97d883279e814e8ddb34d610