### PR TITLE
Fix Mapbox token error

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.42.0
+- Graceful message shown when the Mapbox access token is missing
 ### 2.41.0
 - Driving direction shortcodes `[gn_mapbox_drousia_paphos]`, `[gn_mapbox_drousia_polis]` and `[gn_mapbox_paphos_airport]`
 ### 2.40.0
@@ -64,6 +66,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.42.0
+- Graceful message shown when the Mapbox access token is missing
 ### 2.41.0
 - Driving direction shortcodes `[gn_mapbox_drousia_paphos]`, `[gn_mapbox_drousia_polis]` and `[gn_mapbox_paphos_airport]`
 ### 2.40.0

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -218,3 +218,11 @@
   width: 32px;
   height: 32px;
 }
+
+.gn-mapbox-error {
+  padding: 10px;
+  background: #ffecec;
+  color: #cc0000;
+  border: 1px solid #cc0000;
+  font-family: sans-serif;
+}

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.41.0
+Version: 2.42.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -738,6 +738,9 @@ add_action('admin_post_gn_delete_photo', 'gn_process_photo_deletion');
 */
 function gn_mapbox_drouseia_shortcode() {
     $token = get_option('gn_mapbox_token');
+    if (!$token) {
+        return '<p class="gn-mapbox-error">' . esc_html__('Mapbox access token missing. Set one under Settings → GN Mapbox.', 'gn-mapbox') . '</p>';
+    }
     ob_start();
     ?>
     <div id="gn-mapbox-drouseia" style="width: 100%; height: 400px;"></div>
@@ -807,6 +810,9 @@ add_shortcode('gn_mapbox_drouseia', 'gn_mapbox_drouseia_shortcode');
 
 // Drouseia to Paphos
 function gn_mapbox_drousia_to_paphos_shortcode() {
+    if (!get_option('gn_mapbox_token')) {
+        return '<p class="gn-mapbox-error">' . esc_html__('Mapbox access token missing. Set one under Settings → GN Mapbox.', 'gn-mapbox') . '</p>';
+    }
     ob_start();
     ?>
     <div id="gn-mapbox-drousia-paphos" style="width:100%;height:600px;"></div>
@@ -840,6 +846,9 @@ add_shortcode('gn_mapbox_drousia_paphos', 'gn_mapbox_drousia_to_paphos_shortcode
 
 // Drouseia to Polis
 function gn_mapbox_drousia_to_polis_shortcode() {
+    if (!get_option('gn_mapbox_token')) {
+        return '<p class="gn-mapbox-error">' . esc_html__('Mapbox access token missing. Set one under Settings → GN Mapbox.', 'gn-mapbox') . '</p>';
+    }
     ob_start();
     ?>
     <div id="gn-mapbox-drousia-polis" style="width:100%;height:600px;"></div>
@@ -873,6 +882,9 @@ add_shortcode('gn_mapbox_drousia_polis', 'gn_mapbox_drousia_to_polis_shortcode')
 
 // Paphos to Paphos Airport
 function gn_mapbox_paphos_to_airport_shortcode() {
+    if (!get_option('gn_mapbox_token')) {
+        return '<p class="gn-mapbox-error">' . esc_html__('Mapbox access token missing. Set one under Settings → GN Mapbox.', 'gn-mapbox') . '</p>';
+    }
     ob_start();
     ?>
     <div id="gn-mapbox-paphos-airport" style="width:100%;height:600px;"></div>

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -1,5 +1,13 @@
 document.addEventListener("DOMContentLoaded", function () {
-  if (!document.getElementById("gn-mapbox-map")) return;
+  const container = document.getElementById("gn-mapbox-map");
+  if (!container) return;
+
+  if (!gnMapData.accessToken) {
+    container.innerHTML =
+      '<p class="gn-mapbox-error">Mapbox access token missing. Set one under Settings → GN Mapbox.</p>';
+    console.error("Mapbox access token missing.");
+    return;
+  }
 
   mapboxgl.accessToken = gnMapData.accessToken;
   const debugEnabled = gnMapData.debug === true;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.41.0
+Stable tag: 2.42.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.42.0 =
+* Graceful message displayed when the Mapbox access token is missing
 = 2.41.0 =
 * Driving direction shortcodes `[gn_mapbox_drousia_paphos]`, `[gn_mapbox_drousia_polis]` and `[gn_mapbox_paphos_airport]`
 = 2.40.0 =


### PR DESCRIPTION
## Summary
- show a helpful message when the Mapbox access token is missing
- skip map initialization without a token
- style token error message
- guard direction shortcodes against missing token
- bump to version 2.42.0

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68583db6d9b08327b03f01cb5a4524d2