### PR TITLE
Fix shortcodes token usage and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.43.0
+- Shortcodes now set `mapboxgl.accessToken` from the plugin API key
 ### 2.42.0
 - Graceful message shown when the Mapbox access token is missing
 ### 2.41.0
@@ -66,6 +68,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.43.0
+- Shortcodes now set `mapboxgl.accessToken` from the plugin API key
 ### 2.42.0
 - Graceful message shown when the Mapbox access token is missing
 ### 2.41.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.42.0
+Version: 2.43.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -818,6 +818,7 @@ function gn_mapbox_drousia_to_paphos_shortcode() {
     <div id="gn-mapbox-drousia-paphos" style="width:100%;height:600px;"></div>
     <script>
     jQuery(function(){
+        mapboxgl.accessToken = gnMapData.accessToken;
         const mapDP = new mapboxgl.Map({
             container: 'gn-mapbox-drousia-paphos',
             style: 'mapbox://styles/mapbox/satellite-streets-v11',
@@ -854,6 +855,7 @@ function gn_mapbox_drousia_to_polis_shortcode() {
     <div id="gn-mapbox-drousia-polis" style="width:100%;height:600px;"></div>
     <script>
     jQuery(function(){
+        mapboxgl.accessToken = gnMapData.accessToken;
         const mapDPo = new mapboxgl.Map({
             container: 'gn-mapbox-drousia-polis',
             style: 'mapbox://styles/mapbox/satellite-streets-v11',
@@ -890,6 +892,7 @@ function gn_mapbox_paphos_to_airport_shortcode() {
     <div id="gn-mapbox-paphos-airport" style="width:100%;height:600px;"></div>
     <script>
     jQuery(function(){
+        mapboxgl.accessToken = gnMapData.accessToken;
         const mapPA = new mapboxgl.Map({
             container: 'gn-mapbox-paphos-airport',
             style: 'mapbox://styles/mapbox/satellite-streets-v11',

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.42.0
+Stable tag: 2.43.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.43.0 =
+* Shortcodes now set `mapboxgl.accessToken` from the plugin API key
+
 = 2.42.0 =
 * Graceful message displayed when the Mapbox access token is missing
 = 2.41.0 =


### PR DESCRIPTION
## Summary
- set `mapboxgl.accessToken` in direction shortcodes
- document the changes and bump version to 2.43.0

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68583f7994288327a2c76ae06df7267e