### PR TITLE
Update Directions API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.46.1
+- Set `alternatives=false` for Directions API requests
 ### 2.46.0
 - Added Greek descriptions for locations
 ### 2.45.0
@@ -74,6 +76,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.46.1
+- Set `alternatives=false` for Directions API requests
 ### 2.46.0
 - Added Greek descriptions for locations
 ### 2.45.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.46.0
+Version: 2.46.1
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -264,7 +264,7 @@ document.addEventListener("DOMContentLoaded", function () {
       let segment = allCoords.slice(i, i + MAX);
       if (i !== 0) segment.unshift(allCoords[i - 1]);
       const pairs = segment.map(p => p.join(',')).join(';');
-      let url = `https://api.mapbox.com/directions/v5/mapbox/${mode}/${pairs}?geometries=geojson&overview=full`;
+      let url = `https://api.mapbox.com/directions/v5/mapbox/${mode}/${pairs}?geometries=geojson&overview=full&alternatives=false`;
       if (includeSteps) {
         url += `&steps=true&annotations=duration,distance&language=${lang}`;
       }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.46.0
+Stable tag: 2.46.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.46.1 =
+* Set `alternatives=false` for Directions API requests
 = 2.46.0 =
 * Added Greek descriptions for locations
 = 2.45.0 =


### PR DESCRIPTION
## Summary
- disable alternative routes in Directions API requests
- bump plugin version to 2.46.1 and document changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685906cd1f488327bbbb917cbed61fd6