### PR TITLE
Apply shortcode map settings on route selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.48.0
+- Route settings from direction shortcodes applied to `[gn_map]`
 ### 2.47.0
 - Route selection panel added to `[gn_map]`
 ### 2.46.1
@@ -78,6 +80,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.48.0
+- Map centers and zooms using the driving shortcode settings
 ### 2.47.0
 - Map loads without markers until a route is selected
 ### 2.46.1

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.47.0
+Version: 2.48.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -18,6 +18,12 @@ document.addEventListener("DOMContentLoaded", function () {
   let markers = [];
   let directionsControl;
   const defaultLang = localStorage.getItem("gn_voice_lang") || "el-GR";
+  const routeSettings = {
+    default: { center: [32.3923713, 34.96211], zoom: 16 },
+    paphos: { center: [32.3975751, 34.9627965], zoom: 10 },
+    polis: { center: [32.3975751, 34.9627965], zoom: 11 },
+    airport: { center: [32.4297, 34.7753], zoom: 12 },
+  };
 
   function mapLangPart(code) {
     return code.split("-")[0];
@@ -302,8 +308,18 @@ document.addEventListener("DOMContentLoaded", function () {
     directionsControl.setDestination(dest);
   }
 
+  function applyRouteSettings(key) {
+    const opts = routeSettings[key];
+    if (!opts || !map) return;
+    map.flyTo({ center: opts.center, zoom: opts.zoom });
+  }
+
   function selectRoute(val) {
-    if (!val) { clearMap(); return; }
+    if (!val) {
+      clearMap();
+      return;
+    }
+    applyRouteSettings(val);
     if (val === 'default') {
       showDefaultRoute();
     } else if (val === 'paphos') {
@@ -564,8 +580,8 @@ document.addEventListener("DOMContentLoaded", function () {
   map = new mapboxgl.Map({
     container: "gn-mapbox-map",
     style: "mapbox://styles/mapbox/satellite-streets-v11",
-    center: [32.3923713, 34.96211],
-    zoom: 16,
+    center: routeSettings.default.center,
+    zoom: routeSettings.default.zoom,
   });
 
   map.addControl(new mapboxgl.NavigationControl(), "top-left");

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.47.0
+Stable tag: 2.48.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.48.0 =
+* Map center and zoom now match the individual driving shortcodes
 = 2.47.0 =
 * Map loads empty and routes can be selected
 = 2.46.1 =


### PR DESCRIPTION
## Summary
- respect shortcode map settings when choosing a route in `[gn_map]`
- document new behaviour and bump plugin version to 2.48.0

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597f30a94483278300220ec7accec2