### PR TITLE
Update route option label and debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.49.0
+- Navigation panel option renamed to "Nature Path" and additional console logs added
 ### 2.48.0
 - Route settings from direction shortcodes applied to `[gn_map]`
 ### 2.47.0
@@ -80,6 +82,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.49.0
+- Navigation panel option renamed to "Nature Path" and additional console logs added
 ### 2.48.0
 - Map centers and zooms using the driving shortcode settings
 ### 2.47.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.48.0
+Version: 2.49.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -124,7 +124,7 @@ document.addEventListener("DOMContentLoaded", function () {
       <div style="padding: 6px; background: white;">
           <select id="gn-route-select" class="gn-nav-select">
             <option value="">Select Route</option>
-            <option value="default">Map Locations</option>
+            <option value="default">Nature Path</option>
             <option value="paphos">Drousia → Paphos</option>
             <option value="polis">Drousia → Polis</option>
             <option value="airport">Paphos → Airport</option>
@@ -297,6 +297,7 @@ document.addEventListener("DOMContentLoaded", function () {
   function showDrivingRoute(origin, dest) {
     clearMap();
     coords = [origin, dest];
+    log('Driving route from', origin, 'to', dest);
     directionsControl = new MapboxDirections({
       accessToken: mapboxgl.accessToken,
       unit: 'metric',
@@ -315,6 +316,7 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   function selectRoute(val) {
+    log('Route selected:', val);
     if (!val) {
       clearMap();
       return;
@@ -377,6 +379,7 @@ document.addEventListener("DOMContentLoaded", function () {
         url += `&steps=true&annotations=duration,distance&language=${lang}`;
       }
       url += `&access_token=${mapboxgl.accessToken}`;
+      log('Fetching directions:', url);
 
       const res = await fetch(url);
       const data = await res.json();

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.48.0
+Stable tag: 2.49.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.49.0 =
+* Option label changed to "Nature Path" and added verbose console logs
 = 2.48.0 =
 * Map center and zoom now match the individual driving shortcodes
 = 2.47.0 =


### PR DESCRIPTION
## Summary
- rename the "Map Locations" option to "Nature Path"
- log route selections and directions API requests
- bump plugin version to 2.49.0

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859826b827c8327b3af68fd2acd67c3