### PR TITLE
Fix route dropdown fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.51.0
+- Fetch driving route when changing dropdown options
 ### 2.50.0
 - Added error handling for Directions API requests
 ### 2.49.0
@@ -84,6 +86,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.51.0
+- Fetch driving route when changing dropdown options
 ### 2.50.0
 - Added error handling for Directions API requests
 ### 2.49.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.50.0
+Version: 2.51.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -307,6 +307,8 @@ document.addEventListener("DOMContentLoaded", function () {
     map.addControl(directionsControl, 'top-left');
     directionsControl.setOrigin(origin);
     directionsControl.setDestination(dest);
+    // Trigger a fetch so the URL is logged in debug mode
+    fetchDirections(coords).then(() => {});
   }
 
   function applyRouteSettings(key) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.50.0
+Stable tag: 2.51.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.51.0 =
+* Fetch driving route when changing dropdown options
 = 2.50.0 =
 * Added error handling for Directions API requests
 = 2.49.0 =


### PR DESCRIPTION
## Summary
- fetch directions every time a route option is picked
- bump version to 2.51.0
- document new version in changelogs

## Testing
- `echo "no tests"`

------
https://chatgpt.com/codex/tasks/task_e_685986e7fb0c8327936ff56c39423b14