### PR TITLE
Ensure route redraws on dropdown change

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.52.0
+- Route line and zoom reset when selecting a new route
 ### 2.51.0
 - Fetch driving route when changing dropdown options
 ### 2.50.0
@@ -86,6 +88,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.52.0
+- Route line and zoom reset when selecting a new route
 ### 2.51.0
 - Fetch driving route when changing dropdown options
 ### 2.50.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.51.0
+Version: 2.52.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -243,6 +243,7 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   function clearMap() {
+    log('Clearing map');
     markers.forEach(m => m.remove());
     markers = [];
     const sources = ['route', 'route-tracker', 'trail-line', 'nav-route'];
@@ -259,6 +260,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
   function showDefaultRoute() {
     clearMap();
+    log('Showing default route');
     coords = [];
     gnMapData.locations.forEach((loc) => {
       const galleryHTML = loc.gallery && loc.gallery.length
@@ -296,6 +298,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
   function showDrivingRoute(origin, dest) {
     clearMap();
+    log('Showing driving route');
     coords = [origin, dest];
     log('Driving route from', origin, 'to', dest);
     directionsControl = new MapboxDirections({
@@ -314,15 +317,14 @@ document.addEventListener("DOMContentLoaded", function () {
   function applyRouteSettings(key) {
     const opts = routeSettings[key];
     if (!opts || !map) return;
+    log('Applying route settings:', key, opts);
     map.flyTo({ center: opts.center, zoom: opts.zoom });
   }
 
   function selectRoute(val) {
     log('Route selected:', val);
-    if (!val) {
-      clearMap();
-      return;
-    }
+    clearMap();
+    if (!val) return;
     applyRouteSettings(val);
     if (val === 'default') {
       showDefaultRoute();

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.51.0
+Stable tag: 2.52.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.52.0 =
+* Route line and zoom reset when selecting a new route
 = 2.51.0 =
 * Fetch driving route when changing dropdown options
 = 2.50.0 =


### PR DESCRIPTION
## Summary
- refresh map route when dropdown selection changes
- log map redrawing events for easier debugging
- bump plugin version to 2.52.0

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685988fdffc08327841ae7513d11e7c0