### PR TITLE
Add debug logging and version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
-### 2.52.0
-- Route line and zoom reset when selecting a new route
+### 2.53.0
+- Added console log when the route line is drawn
+- Map recenters when changing routes
 ### 2.51.0
 - Fetch driving route when changing dropdown options
 ### 2.50.0
@@ -88,8 +89,9 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
-### 2.52.0
-- Route line and zoom reset when selecting a new route
+### 2.53.0
+- Added console log when the route line is drawn
+- Map recenters when changing routes
 ### 2.51.0
 - Fetch driving route when changing dropdown options
 ### 2.50.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.52.0
+Version: 2.53.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -288,11 +288,17 @@ document.addEventListener("DOMContentLoaded", function () {
     });
     if (coords.length > 1) {
       fetchDirections(coords).then(res => {
-        if (!res.coordinates.length) return;
+        if (!res.coordinates.length) {
+          log('No coordinates returned for route');
+          return;
+        }
         const routeGeoJson = { type: 'Feature', geometry: { type: 'LineString', coordinates: res.coordinates } };
         map.addSource('route', { type: 'geojson', data: routeGeoJson });
         map.addLayer({ id: 'route', type: 'line', source: 'route', layout: { 'line-join': 'round', 'line-cap': 'round' }, paint: { 'line-color': '#ff0000', 'line-width': 4 } });
+        log('Route line drawn with', res.coordinates.length, 'points');
       });
+    } else {
+      log('Not enough coordinates for route line');
     }
   }
 
@@ -310,6 +316,7 @@ document.addEventListener("DOMContentLoaded", function () {
     map.addControl(directionsControl, 'top-left');
     directionsControl.setOrigin(origin);
     directionsControl.setDestination(dest);
+    log('Directions control added, waiting for route to render');
     // Trigger a fetch so the URL is logged in debug mode
     fetchDirections(coords).then(() => {});
   }
@@ -335,6 +342,8 @@ document.addEventListener("DOMContentLoaded", function () {
     } else if (val === 'airport') {
       showDrivingRoute([32.4297, 34.7753], [32.4858, 34.7174]);
     }
+    // Re-apply the center after controls adjust the map
+    setTimeout(() => applyRouteSettings(val), 1000);
   }
 
   window.setMode = function (mode) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.52.0
+Stable tag: 2.53.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,8 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
-= 2.52.0 =
-* Route line and zoom reset when selecting a new route
+= 2.53.0 =
+* Added console log when the route line is drawn
+* Map recenters when changing routes
 = 2.51.0 =
 * Fetch driving route when changing dropdown options
 = 2.50.0 =


### PR DESCRIPTION
## Summary
- bump plugin version to 2.53.0
- log when route line is drawn and when route coordinates are missing
- log when directions control is added
- recenter map after changing route

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68598b2ce05c8327b47a49c185abc637