### PR TITLE
Fix drouseia_100 map height

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.55.0
+- `[gn_mapbox_drouseia_100]` map fills the entire viewport
 ### 2.54.0
 - Terrain map style for `[gn_mapbox_drouseia]` and new `[gn_mapbox_drouseia_100]`
 - Added `[gn_mapbox_drouseia_100]` shortcode for a full-width map
@@ -92,6 +94,9 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.55.0
+
+- `[gn_mapbox_drouseia_100]` map fills the entire viewport
 ### 2.54.0
 
 - Terrain map style for `[gn_mapbox_drouseia]` and new `[gn_mapbox_drouseia_100]`

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.54.0
+Version: 2.55.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -821,8 +821,7 @@ function gn_mapbox_drouseia_100_shortcode() {
     }
     ob_start();
     ?>
-    <div id="gn-mapbox-drouseia-100" style="width: 100%; height: 400px;"></div>
-    <div id="gn-mapbox-drouseia-100" style="width:100vw;height:400px;"></div>
+    <div id="gn-mapbox-drouseia-100" style="width:100vw;height:100vh;"></div>
     <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
     <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
     <script>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.54.0
+Stable tag: 2.55.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.55.0 =
+* `[gn_mapbox_drouseia_100]` map now fills the entire viewport
 = 2.54.0 =
 * Terrain map style for `[gn_mapbox_drouseia]` and new `[gn_mapbox_drouseia_100]`
 * Added `[gn_mapbox_drouseia_100]` shortcode for a full-width map


### PR DESCRIPTION
## Summary
- make `[gn_mapbox_drouseia_100]` map fill the entire viewport
- bump plugin version to 2.55.0
- document viewport map change in README and readme.txt

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ad76795883279a4c4eec27bf3d44