### PR TITLE
Update drouseia map height

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.56.0
+- `[gn_mapbox_drouseia_100]` height set to 480px
 ### 2.55.0
 - `[gn_mapbox_drouseia_100]` map fills the entire viewport
 ### 2.54.0
@@ -94,6 +96,9 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.56.0
+
+- `[gn_mapbox_drouseia_100]` height set to 480px
 ### 2.55.0
 
 - `[gn_mapbox_drouseia_100]` map fills the entire viewport

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.55.0
+Version: 2.56.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -821,7 +821,7 @@ function gn_mapbox_drouseia_100_shortcode() {
     }
     ob_start();
     ?>
-    <div id="gn-mapbox-drouseia-100" style="width:100vw;height:100vh;"></div>
+    <div id="gn-mapbox-drouseia-100" style="width:100vw;height:480px;"></div>
     <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
     <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
     <script>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.55.0
+Stable tag: 2.56.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.56.0 =
+* `[gn_mapbox_drouseia_100]` height set to 480px
+
 = 2.55.0 =
 * `[gn_mapbox_drouseia_100]` map now fills the entire viewport
 = 2.54.0 =


### PR DESCRIPTION
## Summary
- change `[gn_mapbox_drouseia_100]` map height to 480px
- bump plugin version to 2.56.0
- document the update in README and readme.txt

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b0cc0118832788e6e0be6c69894e