### PR TITLE
Switch maps to terrain style

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.57.0
+- Terrain style enabled for all maps
 ### 2.56.0
 - `[gn_mapbox_drouseia_100]` height set to 480px
 ### 2.55.0
@@ -98,6 +100,9 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.57.0
+
+- Terrain style enabled for all maps
 ### 2.56.0
 
 - `[gn_mapbox_drouseia_100]` height set to 480px

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.56.0
+Version: 2.57.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -843,7 +843,7 @@ function gn_mapbox_drouseia_100_shortcode() {
       mapboxgl.accessToken = '<?php echo esc_js($token); ?>';
         const map = new mapboxgl.Map({
           container: 'gn-mapbox-drouseia-100',
-          style: 'mapbox://styles/mapbox/navigation-day-v1',
+          style: 'mapbox://styles/mapbox/outdoors-v12',
           center: [32.3975751, 34.9627965],
           zoom: 14
         });
@@ -914,7 +914,7 @@ function gn_mapbox_drousia_to_paphos_shortcode() {
         mapboxgl.accessToken = gnMapData.accessToken;
         const mapDP = new mapboxgl.Map({
             container: 'gn-mapbox-drousia-paphos',
-            style: 'mapbox://styles/mapbox/satellite-streets-v11',
+            style: 'mapbox://styles/mapbox/outdoors-v12',
             center: [32.3975751, 34.9627965],
             zoom: 10
         });
@@ -951,7 +951,7 @@ function gn_mapbox_drousia_to_polis_shortcode() {
         mapboxgl.accessToken = gnMapData.accessToken;
         const mapDPo = new mapboxgl.Map({
             container: 'gn-mapbox-drousia-polis',
-            style: 'mapbox://styles/mapbox/satellite-streets-v11',
+            style: 'mapbox://styles/mapbox/outdoors-v12',
             center: [32.3975751, 34.9627965],
             zoom: 11
         });
@@ -988,7 +988,7 @@ function gn_mapbox_paphos_to_airport_shortcode() {
         mapboxgl.accessToken = gnMapData.accessToken;
         const mapPA = new mapboxgl.Map({
             container: 'gn-mapbox-paphos-airport',
-            style: 'mapbox://styles/mapbox/satellite-streets-v11',
+            style: 'mapbox://styles/mapbox/outdoors-v12',
             center: [32.4297, 34.7753],
             zoom: 12
         });

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -604,7 +604,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
   map = new mapboxgl.Map({
     container: "gn-mapbox-map",
-    style: "mapbox://styles/mapbox/satellite-streets-v11",
+    style: "mapbox://styles/mapbox/outdoors-v12",
     center: routeSettings.default.center,
     zoom: routeSettings.default.zoom,
   });

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.56.0
+Stable tag: 2.57.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.57.0 =
+* Terrain style enabled for all maps
 = 2.56.0 =
 * `[gn_mapbox_drouseia_100]` height set to 480px
 


### PR DESCRIPTION
## Summary
- use terrain map style for all maps
- bump plugin version to 2.57.0

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b2b6e9408327ab84e215f55c3236