### PR TITLE
Improve via waypoint handling and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.60.0
+- Hidden coordinates now sent as via waypoints for navigation
 ### 2.59.0
 - Use Mapbox via_waypoints for navigation
 ### 2.58.0
@@ -104,6 +106,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.60.0
+- Hidden coordinates now sent as via waypoints for navigation
 ### 2.59.0
 - Use Mapbox via_waypoints for navigation
 ### 2.58.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.59.0
+Version: 2.60.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -458,7 +458,11 @@ document.addEventListener("DOMContentLoaded", function () {
       const waypoints = coords.slice(0, -1);
       const destination = coords[coords.length - 1];
       const ordered = [userLngLat, ...waypoints, destination];
-      const stopIdx = [0, ordered.length - 1];
+      const stopIdx = [0];
+      gnMapData.locations.forEach((loc, i) => {
+        if (!loc.waypoint) stopIdx.push(i + 1);
+      });
+      if (!stopIdx.includes(ordered.length - 1)) stopIdx.push(ordered.length - 1);
       const {
         coordinates: routeCoords,
         steps,

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.59.0
+Stable tag: 2.60.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.60.0 =
+* Hidden coordinates sent as via waypoints for navigation
 = 2.59.0 =
 * Use Mapbox via_waypoints correctly for navigation
 


### PR DESCRIPTION
## Summary
- mark hidden coordinates as via waypoints when navigating
- document the change
- bump stable version to 2.60.0

## Testing
- `npm test` *(fails: ENOENT could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859bb9265fc83278010f4c87941396b