### PR TITLE
Fix invalid Mapbox query

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.61.0
+- Fix Mapbox "Invalid query param" error during navigation
+
 ### 2.60.0
 - Hidden coordinates now sent as via waypoints for navigation
 ### 2.59.0
@@ -106,6 +109,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.61.0
+- Fix Mapbox "Invalid query param" error during navigation
 ### 2.60.0
 - Hidden coordinates now sent as via waypoints for navigation
 ### 2.59.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.60.0
+Version: 2.61.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -397,12 +397,16 @@ document.addEventListener("DOMContentLoaded", function () {
           segment.unshift(allCoords[i - 1]);
           segStart = i - 1;
         }
-        const localStops = stopIndices
+        let localStops = stopIndices
           .filter(idx => idx >= segStart && idx < segStart + segment.length)
           .map(idx => idx - segStart);
         const pairs = segment.map(p => p.join(',')).join(';');
         let url = `https://api.mapbox.com/directions/v5/mapbox/${mode}/${pairs}?geometries=geojson&overview=full&alternatives=false`;
         if (localStops.length) {
+          if (!localStops.includes(0)) localStops.unshift(0);
+          const lastIdx = segment.length - 1;
+          if (!localStops.includes(lastIdx)) localStops.push(lastIdx);
+          localStops = Array.from(new Set(localStops)).sort((a, b) => a - b);
           url += `&waypoint_indices=${localStops.join(';')}`;
         }
         if (includeSteps) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.60.0
+Stable tag: 2.61.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.61.0 =
+* Fix "Invalid query param" error from Mapbox Directions
 = 2.60.0 =
 * Hidden coordinates sent as via waypoints for navigation
 = 2.59.0 =


### PR DESCRIPTION
## Summary
- ensure waypoint indices include first and last points
- bump plugin version to 2.61.0

## Testing
- `npm -v`
- `node -v`
- `php -l gn-mapbox-plugin.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859bd4e46048327b7679d8e2f6cb949