### PR TITLE
Bump plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.62.0
+- Bump plugin version
 ### 2.61.0
 - Fix Mapbox "Invalid query param" error during navigation
 
@@ -109,6 +111,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.62.0
+- Bump plugin version
 ### 2.61.0
 - Fix Mapbox "Invalid query param" error during navigation
 ### 2.60.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.61.0
+Version: 2.62.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.61.0
+Stable tag: 2.62.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.62.0 =
+* Bump plugin version
 = 2.61.0 =
 * Fix "Invalid query param" error from Mapbox Directions
 = 2.60.0 =


### PR DESCRIPTION
## Summary
- bump plugin version to 2.62.0
- document the version bump in changelogs

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859beddcf048327ae24c1042819ee76