### PR TITLE
Fix Mapbox 422 error on Nature Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.63.0
+- Nature Path route uses walking directions
 ### 2.62.0
 - Bump plugin version
 ### 2.61.0
@@ -111,6 +113,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.63.0
+- Nature Path route uses walking directions
 ### 2.62.0
 - Bump plugin version
 ### 2.61.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.62.0
+Version: 2.63.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -293,7 +293,7 @@ document.addEventListener("DOMContentLoaded", function () {
       });
       if (!stopIdx.includes(0)) stopIdx.unshift(0);
       if (!stopIdx.includes(coords.length - 1)) stopIdx.push(coords.length - 1);
-      fetchDirections(coords, 'driving', false, mapLangPart(getSelectedLanguage()), stopIdx).then(res => {
+      fetchDirections(coords, 'walking', false, mapLangPart(getSelectedLanguage()), stopIdx).then(res => {
         if (!res.coordinates.length) {
           log('No coordinates returned for route');
           return;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.62.0
+Stable tag: 2.63.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.63.0 =
+* Nature Path route uses walking directions
 = 2.62.0 =
 * Bump plugin version
 = 2.61.0 =


### PR DESCRIPTION
## Summary
- use walking directions when fetching the Nature Path
- bump plugin version to 2.63.0
- document the walking route change

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859c02bff888327b49602d30c1a88f7