### PR TITLE
Ensure route logs when dropdown changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.59.0
+- Verify route line draws when selecting a new option
 ### 2.58.0
 - Satellite streets style for all maps
 ### 2.57.0
@@ -102,6 +104,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.59.0
+- Verify route line draws when selecting a new option
 ### 2.58.0
 
 - Satellite streets style for all maps

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.58.0
+Version: 2.59.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -313,6 +313,12 @@ document.addEventListener("DOMContentLoaded", function () {
       profile: 'mapbox/driving',
       alternatives: false
     });
+    directionsControl.on('route', (e) => {
+      const pts = e.route && e.route[0] && e.route[0].geometry
+        ? e.route[0].geometry.coordinates.length
+        : 0;
+      log('Driving route drawn with', pts, 'points');
+    });
     map.addControl(directionsControl, 'top-left');
     directionsControl.setOrigin(origin);
     directionsControl.setDestination(dest);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.58.0
+Stable tag: 2.59.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.59.0 =
+* Verify route line draws when changing dropdown
 = 2.58.0 =
 * Satellite streets style for all maps
 = 2.57.0 =


### PR DESCRIPTION
## Summary
- verify driving routes draw when dropdown changes
- bump plugin version to 2.59.0

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859c3b85c6c83279a751c572f9f1741