### PR TITLE
Fix Mapbox geometry error and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.60.0
+- Fix error when Mapbox Directions geometry is missing
 ### 2.59.0
 - Verify route line draws when selecting a new option
 ### 2.58.0
@@ -104,6 +106,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.60.0
+- Fix error when Mapbox Directions geometry is missing
 ### 2.59.0
 - Verify route line draws when selecting a new option
 ### 2.58.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.59.0
+Version: 2.60.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -288,7 +288,7 @@ document.addEventListener("DOMContentLoaded", function () {
     });
     if (coords.length > 1) {
       fetchDirections(coords).then(res => {
-        if (!res.coordinates.length) {
+        if (!res.coordinates || !res.coordinates.length) {
           log('No coordinates returned for route');
           return;
         }
@@ -314,7 +314,7 @@ document.addEventListener("DOMContentLoaded", function () {
       alternatives: false
     });
     directionsControl.on('route', (e) => {
-      const pts = e.route && e.route[0] && e.route[0].geometry
+      const pts = e.route && e.route[0] && e.route[0].geometry && e.route[0].geometry.coordinates
         ? e.route[0].geometry.coordinates.length
         : 0;
       log('Driving route drawn with', pts, 'points');

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.59.0
+Stable tag: 2.60.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.60.0 =
+* Fix error when Mapbox Directions geometry is missing
 = 2.59.0 =
 * Verify route line draws when changing dropdown
 = 2.58.0 =


### PR DESCRIPTION
## Summary
- handle missing geometry coordinates when drawing routes
- bump plugin version to 2.60.0
- update changelogs

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6859c538948883279253fdd421d5dd0d