### PR TITLE
Reverse driving directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.61.0
+- Reverse driving directions for Paphos Airport, Drousia to Paphos and Drousia to Polis
 ### 2.60.0
 - Fix error when Mapbox Directions geometry is missing
 ### 2.59.0
@@ -106,6 +108,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.61.0
+- Reverse driving directions for Paphos Airport, Drousia to Paphos and Drousia to Polis
 ### 2.60.0
 - Fix error when Mapbox Directions geometry is missing
 ### 2.59.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.60.0
+Version: 2.61.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -928,8 +928,8 @@ function gn_mapbox_drousia_to_paphos_shortcode() {
 
         mapDP.addControl(directionsDP, 'top-left');
         mapDP.on('load', function() {
-            directionsDP.setOrigin([32.3975751, 34.9627965]);
-            directionsDP.setDestination([32.4297, 34.7753]);
+            directionsDP.setOrigin([32.4297, 34.7753]);
+            directionsDP.setDestination([32.3975751, 34.9627965]);
         });
     });
     </script>
@@ -965,8 +965,8 @@ function gn_mapbox_drousia_to_polis_shortcode() {
 
         mapDPo.addControl(directionsDPo, 'top-left');
         mapDPo.on('load', function() {
-            directionsDPo.setOrigin([32.3975751, 34.9627965]);
-            directionsDPo.setDestination([32.4147, 35.0360]);
+            directionsDPo.setOrigin([32.4147, 35.0360]);
+            directionsDPo.setDestination([32.3975751, 34.9627965]);
         });
     });
     </script>
@@ -1002,8 +1002,8 @@ function gn_mapbox_paphos_to_airport_shortcode() {
 
         mapPA.addControl(directionsPA, 'top-left');
         mapPA.on('load', function() {
-            directionsPA.setOrigin([32.4297, 34.7753]);
-            directionsPA.setDestination([32.4858, 34.7174]);
+            directionsPA.setOrigin([32.4858, 34.7174]);
+            directionsPA.setDestination([32.4297, 34.7753]);
         });
     });
     </script>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.60.0
+Stable tag: 2.61.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.61.0 =
+* Reverse driving directions for Paphos Airport, Drousia to Paphos and Drousia to Polis
 = 2.60.0 =
 * Fix error when Mapbox Directions geometry is missing
 = 2.59.0 =


### PR DESCRIPTION
## Summary
- flip origin/destination for Paphos Airport, Drousia–Paphos and Drousia–Polis
- bump version to 2.61.0

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859c7c524648327a61ec515460534e5