### PR TITLE
Update Mapbox dependencies and fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.62.0
+- Update Mapbox GL JS and directions plugin versions
+
 ### 2.61.0
 - Reverse driving directions for Paphos Airport, Drousia to Paphos and Drousia to Polis
 ### 2.60.0
@@ -108,6 +111,9 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.62.0
+- Update Mapbox GL JS and directions plugin versions
+
 ### 2.61.0
 - Reverse driving directions for Paphos Airport, Drousia to Paphos and Drousia to Polis
 ### 2.60.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.61.0
+Version: 2.62.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -325,11 +325,11 @@ function gn_save_quick_edit_order($post_id) {
 add_action('save_post_map_location', 'gn_save_quick_edit_order');
 
 function gn_enqueue_mapbox_assets() {
-    wp_enqueue_style('mapbox-gl', 'https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css');
-    wp_enqueue_style('mapbox-gl-directions', 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v4.1.1/mapbox-gl-directions.css');
+    wp_enqueue_style('mapbox-gl', 'https://api.mapbox.com/mapbox-gl-js/v2.15.1/mapbox-gl.css');
+    wp_enqueue_style('mapbox-gl-directions', 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v4.2.0/mapbox-gl-directions.css');
     wp_enqueue_style('gn-mapbox-style', plugin_dir_url(__FILE__) . 'css/mapbox-style.css');
-    wp_enqueue_script('mapbox-gl', 'https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js', [], null, true);
-    wp_enqueue_script('mapbox-gl-directions', 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v4.1.1/mapbox-gl-directions.js', ['mapbox-gl'], null, true);
+    wp_enqueue_script('mapbox-gl', 'https://api.mapbox.com/mapbox-gl-js/v2.15.1/mapbox-gl.js', [], null, true);
+    wp_enqueue_script('mapbox-gl-directions', 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v4.2.0/mapbox-gl-directions.js', ['mapbox-gl'], null, true);
     wp_enqueue_script('chartjs', 'https://cdn.jsdelivr.net/npm/chart.js', [], null, true);
     wp_enqueue_script('mapbox-gl-language', plugin_dir_url(__FILE__) . 'js/mapbox-gl-language.js', ['mapbox-gl'], null, true);
     wp_enqueue_script('gn-mapbox-init', plugin_dir_url(__FILE__) . 'js/mapbox-init.js', ['jquery', 'mapbox-gl-language', 'mapbox-gl-directions'], null, true);
@@ -761,8 +761,8 @@ function gn_mapbox_drouseia_shortcode() {
     ob_start();
     ?>
     <div id="gn-mapbox-drouseia" style="width: 100%; height: 400px;"></div>
-    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
-    <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.1/mapbox-gl.js"></script>
+    <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.1/mapbox-gl.css" rel="stylesheet" />
     <script>
       mapboxgl.accessToken = '<?php echo esc_js($token); ?>';
         const map = new mapboxgl.Map({
@@ -837,8 +837,8 @@ function gn_mapbox_drouseia_100_shortcode() {
     ob_start();
     ?>
     <div id="gn-mapbox-drouseia-100" style="width:100vw;height:480px;"></div>
-    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
-    <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.1/mapbox-gl.js"></script>
+    <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.1/mapbox-gl.css" rel="stylesheet" />
     <script>
       mapboxgl.accessToken = '<?php echo esc_js($token); ?>';
         const map = new mapboxgl.Map({

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -313,12 +313,33 @@ document.addEventListener("DOMContentLoaded", function () {
       profile: 'mapbox/driving',
       alternatives: false
     });
-    directionsControl.on('route', (e) => {
+  directionsControl.on('route', (e) => {
       const pts = e.route && e.route[0] && e.route[0].geometry && e.route[0].geometry.coordinates
         ? e.route[0].geometry.coordinates.length
         : 0;
       log('Driving route drawn with', pts, 'points');
-    });
+      if (pts === 0) {
+        fetchDirections([origin, dest]).then(res => {
+          if (!res.coordinates || !res.coordinates.length) {
+            log('No route coordinates returned');
+            return;
+          }
+          const geo = { type: 'Feature', geometry: { type: 'LineString', coordinates: res.coordinates } };
+          if (map.getSource('driving-route')) {
+            map.getSource('driving-route').setData(geo);
+          } else {
+            map.addSource('driving-route', { type: 'geojson', data: geo });
+            map.addLayer({
+              id: 'driving-route',
+              type: 'line',
+              source: 'driving-route',
+              paint: { 'line-color': '#007cbf', 'line-width': 6 }
+            });
+          }
+          log('Route line drawn manually with', res.coordinates.length, 'points');
+        });
+      }
+  });
     map.addControl(directionsControl, 'top-left');
     directionsControl.setOrigin(origin);
     directionsControl.setDestination(dest);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.61.0
+Stable tag: 2.62.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.62.0 =
+* Update Mapbox GL JS and directions plugin versions
+
 = 2.61.0 =
 * Reverse driving directions for Paphos Airport, Drousia to Paphos and Drousia to Polis
 = 2.60.0 =


### PR DESCRIPTION
## Summary
- update Mapbox GL JS and directions plugin
- add fallback route drawing when Mapbox Directions fails
- bump plugin version to 2.62.0
- document latest changes

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859c955fa108327992ae679f9f2f375