### PR TITLE
Revert to plugin version 2.58.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,6 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
-### 2.62.0
-- Update Mapbox GL JS and directions plugin versions
-
-### 2.61.0
-- Reverse driving directions for Paphos Airport, Drousia to Paphos and Drousia to Polis
-### 2.60.0
-- Fix error when Mapbox Directions geometry is missing
-### 2.59.0
-- Verify route line draws when selecting a new option
 ### 2.58.0
 - Satellite streets style for all maps
 ### 2.57.0
@@ -111,15 +102,6 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
-### 2.62.0
-- Update Mapbox GL JS and directions plugin versions
-
-### 2.61.0
-- Reverse driving directions for Paphos Airport, Drousia to Paphos and Drousia to Polis
-### 2.60.0
-- Fix error when Mapbox Directions geometry is missing
-### 2.59.0
-- Verify route line draws when selecting a new option
 ### 2.58.0
 
 - Satellite streets style for all maps

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.62.0
+Version: 2.58.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -325,11 +325,11 @@ function gn_save_quick_edit_order($post_id) {
 add_action('save_post_map_location', 'gn_save_quick_edit_order');
 
 function gn_enqueue_mapbox_assets() {
-    wp_enqueue_style('mapbox-gl', 'https://api.mapbox.com/mapbox-gl-js/v2.15.1/mapbox-gl.css');
-    wp_enqueue_style('mapbox-gl-directions', 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v4.2.0/mapbox-gl-directions.css');
+    wp_enqueue_style('mapbox-gl', 'https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css');
+    wp_enqueue_style('mapbox-gl-directions', 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v4.1.1/mapbox-gl-directions.css');
     wp_enqueue_style('gn-mapbox-style', plugin_dir_url(__FILE__) . 'css/mapbox-style.css');
-    wp_enqueue_script('mapbox-gl', 'https://api.mapbox.com/mapbox-gl-js/v2.15.1/mapbox-gl.js', [], null, true);
-    wp_enqueue_script('mapbox-gl-directions', 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v4.2.0/mapbox-gl-directions.js', ['mapbox-gl'], null, true);
+    wp_enqueue_script('mapbox-gl', 'https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js', [], null, true);
+    wp_enqueue_script('mapbox-gl-directions', 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v4.1.1/mapbox-gl-directions.js', ['mapbox-gl'], null, true);
     wp_enqueue_script('chartjs', 'https://cdn.jsdelivr.net/npm/chart.js', [], null, true);
     wp_enqueue_script('mapbox-gl-language', plugin_dir_url(__FILE__) . 'js/mapbox-gl-language.js', ['mapbox-gl'], null, true);
     wp_enqueue_script('gn-mapbox-init', plugin_dir_url(__FILE__) . 'js/mapbox-init.js', ['jquery', 'mapbox-gl-language', 'mapbox-gl-directions'], null, true);
@@ -761,8 +761,8 @@ function gn_mapbox_drouseia_shortcode() {
     ob_start();
     ?>
     <div id="gn-mapbox-drouseia" style="width: 100%; height: 400px;"></div>
-    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.1/mapbox-gl.js"></script>
-    <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.1/mapbox-gl.css" rel="stylesheet" />
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
+    <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
     <script>
       mapboxgl.accessToken = '<?php echo esc_js($token); ?>';
         const map = new mapboxgl.Map({
@@ -837,8 +837,8 @@ function gn_mapbox_drouseia_100_shortcode() {
     ob_start();
     ?>
     <div id="gn-mapbox-drouseia-100" style="width:100vw;height:480px;"></div>
-    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.1/mapbox-gl.js"></script>
-    <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.1/mapbox-gl.css" rel="stylesheet" />
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
+    <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
     <script>
       mapboxgl.accessToken = '<?php echo esc_js($token); ?>';
         const map = new mapboxgl.Map({
@@ -928,8 +928,8 @@ function gn_mapbox_drousia_to_paphos_shortcode() {
 
         mapDP.addControl(directionsDP, 'top-left');
         mapDP.on('load', function() {
-            directionsDP.setOrigin([32.4297, 34.7753]);
-            directionsDP.setDestination([32.3975751, 34.9627965]);
+            directionsDP.setOrigin([32.3975751, 34.9627965]);
+            directionsDP.setDestination([32.4297, 34.7753]);
         });
     });
     </script>
@@ -965,8 +965,8 @@ function gn_mapbox_drousia_to_polis_shortcode() {
 
         mapDPo.addControl(directionsDPo, 'top-left');
         mapDPo.on('load', function() {
-            directionsDPo.setOrigin([32.4147, 35.0360]);
-            directionsDPo.setDestination([32.3975751, 34.9627965]);
+            directionsDPo.setOrigin([32.3975751, 34.9627965]);
+            directionsDPo.setDestination([32.4147, 35.0360]);
         });
     });
     </script>
@@ -1002,8 +1002,8 @@ function gn_mapbox_paphos_to_airport_shortcode() {
 
         mapPA.addControl(directionsPA, 'top-left');
         mapPA.on('load', function() {
-            directionsPA.setOrigin([32.4858, 34.7174]);
-            directionsPA.setDestination([32.4297, 34.7753]);
+            directionsPA.setOrigin([32.4297, 34.7753]);
+            directionsPA.setDestination([32.4858, 34.7174]);
         });
     });
     </script>

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -288,7 +288,7 @@ document.addEventListener("DOMContentLoaded", function () {
     });
     if (coords.length > 1) {
       fetchDirections(coords).then(res => {
-        if (!res.coordinates || !res.coordinates.length) {
+        if (!res.coordinates.length) {
           log('No coordinates returned for route');
           return;
         }
@@ -313,33 +313,6 @@ document.addEventListener("DOMContentLoaded", function () {
       profile: 'mapbox/driving',
       alternatives: false
     });
-  directionsControl.on('route', (e) => {
-      const pts = e.route && e.route[0] && e.route[0].geometry && e.route[0].geometry.coordinates
-        ? e.route[0].geometry.coordinates.length
-        : 0;
-      log('Driving route drawn with', pts, 'points');
-      if (pts === 0) {
-        fetchDirections([origin, dest]).then(res => {
-          if (!res.coordinates || !res.coordinates.length) {
-            log('No route coordinates returned');
-            return;
-          }
-          const geo = { type: 'Feature', geometry: { type: 'LineString', coordinates: res.coordinates } };
-          if (map.getSource('driving-route')) {
-            map.getSource('driving-route').setData(geo);
-          } else {
-            map.addSource('driving-route', { type: 'geojson', data: geo });
-            map.addLayer({
-              id: 'driving-route',
-              type: 'line',
-              source: 'driving-route',
-              paint: { 'line-color': '#007cbf', 'line-width': 6 }
-            });
-          }
-          log('Route line drawn manually with', res.coordinates.length, 'points');
-        });
-      }
-  });
     map.addControl(directionsControl, 'top-left');
     directionsControl.setOrigin(origin);
     directionsControl.setDestination(dest);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.62.0
+Stable tag: 2.58.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,15 +40,6 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
-= 2.62.0 =
-* Update Mapbox GL JS and directions plugin versions
-
-= 2.61.0 =
-* Reverse driving directions for Paphos Airport, Drousia to Paphos and Drousia to Polis
-= 2.60.0 =
-* Fix error when Mapbox Directions geometry is missing
-= 2.59.0 =
-* Verify route line draws when changing dropdown
 = 2.58.0 =
 * Satellite streets style for all maps
 = 2.57.0 =


### PR DESCRIPTION
## Summary
- revert plugin version to 2.58.0
- roll back docs to match 2.58.0 release
- remove later route tracking updates

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859cb155168832796f49c16ceb8d775