### PR TITLE
Fix driving route display and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.59.0
+- Driving routes now draw a line using the Directions API
 ### 2.58.0
 - Satellite streets style for all maps
 ### 2.57.0
@@ -102,6 +104,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.59.0
+- Driving routes now draw a line using the Directions API
 ### 2.58.0
 
 - Satellite streets style for all maps

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.58.0
+Version: 2.59.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -302,7 +302,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   }
 
-  function showDrivingRoute(origin, dest) {
+  async function showDrivingRoute(origin, dest) {
     clearMap();
     log('Showing driving route');
     coords = [origin, dest];
@@ -317,8 +317,22 @@ document.addEventListener("DOMContentLoaded", function () {
     directionsControl.setOrigin(origin);
     directionsControl.setDestination(dest);
     log('Directions control added, waiting for route to render');
-    // Trigger a fetch so the URL is logged in debug mode
-    fetchDirections(coords).then(() => {});
+
+    const res = await fetchDirections(coords);
+    if (res.coordinates.length) {
+      const routeGeoJson = { type: 'Feature', geometry: { type: 'LineString', coordinates: res.coordinates } };
+      map.addSource('route', { type: 'geojson', data: routeGeoJson });
+      map.addLayer({
+        id: 'route',
+        type: 'line',
+        source: 'route',
+        layout: { 'line-join': 'round', 'line-cap': 'round' },
+        paint: { 'line-color': '#ff0000', 'line-width': 4 }
+      });
+      log('Route line drawn with', res.coordinates.length, 'points');
+    } else {
+      log('No coordinates returned for route');
+    }
   }
 
   function applyRouteSettings(key) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.58.0
+Stable tag: 2.59.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.59.0 =
+* Driving routes now draw a line using the Directions API
 = 2.58.0 =
 * Satellite streets style for all maps
 = 2.57.0 =


### PR DESCRIPTION
## Summary
- draw driving routes with a line using Directions API results
- bump plugin version to 2.59.0
- document update in changelogs

## Testing
- `node --check js/mapbox-init.js`
- ❌ `php -l gn-mapbox-plugin.php` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ccdca3fc8327885c90f8a6dd4f02