### PR TITLE
Narrow nav panel and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.62.0
+- Navigation panel width reduced for better responsiveness
 ### 2.61.0
 - Navigation panel can be closed and reopened
 - Directions instructions panel hidden
@@ -111,6 +113,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.62.0
+- Navigation panel width reduced for better responsiveness
 ### 2.61.0
 - Navigation panel can be closed and reopened
 - Directions instructions panel hidden

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -234,6 +234,6 @@
   border: none;
   cursor: pointer;
   z-index: 9998;
-  width: 40px;
+  width: 30px;
   padding: 4px;
 }

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.61.0
+Version: 2.62.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -151,7 +151,7 @@ document.addEventListener("DOMContentLoaded", function () {
       position: fixed;
       top: 100px;
       left: 10px;
-      width: 140px;
+      width: 120px;
       z-index: 9998;
       border: 1px solid #ccc;
       box-shadow: 0 2px 5px rgba(0,0,0,0.3);
@@ -164,7 +164,7 @@ document.addEventListener("DOMContentLoaded", function () {
     openBtn.id = 'gn-open-nav';
     openBtn.textContent = '☰';
     openBtn.className = 'gn-nav-btn';
-    openBtn.style.cssText = 'position:fixed;top:100px;left:10px;z-index:9998;width:40px;display:none;padding:4px;';
+    openBtn.style.cssText = 'position:fixed;top:100px;left:10px;z-index:9998;width:30px;display:none;padding:4px;';
     document.body.appendChild(openBtn);
     openBtn.onclick = () => {
       navPanel.style.display = 'block';

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.61.0
+Stable tag: 2.62.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.62.0 =
+* Navigation panel width reduced for better responsiveness
 = 2.61.0 =
 * Navigation panel can be closed and reopened
 * Directions instructions panel hidden


### PR DESCRIPTION
## Summary
- narrow the navigation panel and open button width
- bump plugin version to 2.62.0
- document the change in README and readme.txt

## Testing
- `node --check js/mapbox-init.js`

------
https://chatgpt.com/codex/tasks/task_e_685a604b4e348327b50a759b67799f3b