### PR TITLE
Compact nav panel with icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.63.0
+- Navigation panel uses flag and mode icons and slimmer controls
 ### 2.62.0
 - Navigation panel width reduced for better responsiveness
 ### 2.61.0
@@ -113,6 +115,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.63.0
+- Navigation panel uses flag and mode icons and slimmer controls
 ### 2.62.0
 - Navigation panel width reduced for better responsiveness
 ### 2.61.0

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -149,6 +149,10 @@
   font-size: 13px;
 }
 
+#gn-route-select {
+  width: 90px;
+}
+
 #gn-distance-panel {
   font-size: 12px;
   margin-bottom: 4px;

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.62.0
+Version: 2.63.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -135,13 +135,13 @@ document.addEventListener("DOMContentLoaded", function () {
             <option value="airport">Paphos → Airport</option>
           </select>
           <select id="gn-mode-select" class="gn-nav-select">
-            <option value="driving">Driving</option>
-            <option value="walking">Walking</option>
-            <option value="cycling">Cycling</option>
+            <option value="driving" title="Driving">🚗</option>
+            <option value="walking" title="Walking">🚶</option>
+            <option value="cycling" title="Cycling">🚲</option>
           </select>
           <select id="gn-language-select" class="gn-nav-select">
-            <option value="en-US">English</option>
-            <option value="el-GR">Ελληνικά</option>
+            <option value="en-US" title="English">🇬🇧</option>
+            <option value="el-GR" title="Ελληνικά">🇬🇷</option>
           </select>
           <div id="gn-distance-panel" style="font-size:12px;margin-bottom:4px;"></div>
           <button class="gn-nav-btn" id="gn-start-nav" title="Start Navigation">▶</button>
@@ -151,7 +151,7 @@ document.addEventListener("DOMContentLoaded", function () {
       position: fixed;
       top: 100px;
       left: 10px;
-      width: 120px;
+      width: 110px;
       z-index: 9998;
       border: 1px solid #ccc;
       box-shadow: 0 2px 5px rgba(0,0,0,0.3);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.62.0
+Stable tag: 2.63.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.63.0 =
+* Navigation panel uses flag and mode icons and slimmer controls
 = 2.62.0 =
 * Navigation panel width reduced for better responsiveness
 = 2.61.0 =


### PR DESCRIPTION
## Summary
- add flag icons for language selector and emoji icons for mode selector
- narrow the route dropdown width
- reduce nav panel width
- bump plugin version to 2.63.0

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a62f8c6d483278842385da923ddc8