### PR TITLE
Fix default Mapbox route duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.64.0
+- Clear leftover MapboxDirections layers when switching routes
 ### 2.63.0
 - Navigation panel uses flag and mode icons and slimmer controls
 ### 2.62.0
@@ -115,6 +117,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.64.0
+- Clear leftover MapboxDirections layers when switching routes
 ### 2.63.0
 - Navigation panel uses flag and mode icons and slimmer controls
 ### 2.62.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.63.0
+Version: 2.64.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -275,6 +275,15 @@ document.addEventListener("DOMContentLoaded", function () {
       map.removeControl(directionsControl);
       directionsControl = null;
     }
+    const style = map.getStyle();
+    if (style) {
+      Object.keys(style.sources)
+        .filter(id => id.startsWith('directions'))
+        .forEach(id => {
+          if (map.getLayer(id)) map.removeLayer(id);
+          if (map.getSource(id)) map.removeSource(id);
+        });
+    }
     const panel = document.getElementById('gn-distance-panel');
     if (panel) panel.textContent = '';
     if (watchId) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.63.0
+Stable tag: 2.64.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.64.0 =
+* Clear leftover MapboxDirections layers when switching routes
 = 2.63.0 =
 * Navigation panel uses flag and mode icons and slimmer controls
 = 2.62.0 =


### PR DESCRIPTION
## Summary
- remove leftover `MapboxDirections` layers when clearing the map
- bump plugin version to 2.64.0
- document fix in change log

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be44679a48327b743686f31ca4e65