### PR TITLE
Fix mobile panel widths

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.65.0
+- Navigation and debug panel widths consistent on mobile
 ### 2.64.0
 - Clear leftover MapboxDirections layers when switching routes
 ### 2.63.0
@@ -117,6 +119,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.65.0
+- Navigation and debug panel widths consistent on mobile
 ### 2.64.0
 - Clear leftover MapboxDirections layers when switching routes
 ### 2.63.0

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -115,12 +115,12 @@
 /* Navigation panel override for mobile */
 @media (max-width: 767px) {
   #gn-nav-panel {
-    width: 90vw !important;
+    width: 110px !important;
     left: 5vw !important;
     top: 10vh !important;
   }
   #gn-debug-panel {
-    width: 90vw !important;
+    width: 300px !important;
     right: 5vw !important;
     bottom: 10vh !important;
   }

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.64.0
+Version: 2.65.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.64.0
+Stable tag: 2.65.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.65.0 =
+* Navigation and debug panel widths consistent on mobile
 = 2.64.0 =
 * Clear leftover MapboxDirections layers when switching routes
 = 2.63.0 =


### PR DESCRIPTION
## Summary
- make nav and debug panel width consistent on mobile
- bump plugin version to 2.65.0

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685beaf6ee5c83279030e7c03eea690b