### PR TITLE
Fix duplicate driving route line

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.66.0
+- Driving routes no longer draw duplicate lines
 ### 2.65.0
 - Navigation and debug panel widths consistent on mobile
 ### 2.64.0
@@ -119,6 +121,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.66.0
+- Driving routes no longer draw duplicate lines
 ### 2.65.0
 - Navigation and debug panel widths consistent on mobile
 ### 2.64.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.65.0
+Version: 2.66.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -353,22 +353,6 @@ document.addEventListener("DOMContentLoaded", function () {
     directionsControl.setOrigin(origin);
     directionsControl.setDestination(dest);
     log('Directions control added, waiting for route to render');
-
-    const res = await fetchDirections(coords);
-    if (res.coordinates.length) {
-      const routeGeoJson = { type: 'Feature', geometry: { type: 'LineString', coordinates: res.coordinates } };
-      map.addSource('route', { type: 'geojson', data: routeGeoJson });
-      map.addLayer({
-        id: 'route',
-        type: 'line',
-        source: 'route',
-        layout: { 'line-join': 'round', 'line-cap': 'round' },
-        paint: { 'line-color': '#ff0000', 'line-width': 4 }
-      });
-      log('Route line drawn with', res.coordinates.length, 'points');
-    } else {
-      log('No coordinates returned for route');
-    }
   }
 
   function applyRouteSettings(key) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.65.0
+Stable tag: 2.66.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.66.0 =
+* Driving routes no longer duplicate lines
 = 2.65.0 =
 * Navigation and debug panel widths consistent on mobile
 = 2.64.0 =


### PR DESCRIPTION
## Summary
- avoid drawing manual route after MapboxDirections renders route
- bump plugin version to 2.66.0
- document changes in README files

## Testing
- `node --check js/mapbox-init.js`

------
https://chatgpt.com/codex/tasks/task_e_685bedd3c45c83278e9ee79c076e98cb