### PR TITLE
Fix navigation seam duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.67.0
+- Driving routes no longer kink at chunk seams
 ### 2.66.0
 - Driving routes no longer draw duplicate lines
 ### 2.65.0
@@ -121,6 +123,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.67.0
+- Driving routes no longer kink at chunk seams
 ### 2.66.0
 - Driving routes no longer draw duplicate lines
 ### 2.65.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.66.0
+Version: 2.67.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -449,7 +449,16 @@ document.addEventListener("DOMContentLoaded", function () {
         if (!data.routes || !data.routes[0]) continue;
         const segCoords = data.routes[0].geometry.coordinates;
         if (routeCoords.length) {
-          routeCoords = routeCoords.concat(segCoords.slice(1));
+          routeCoords = routeCoords.concat(
+            segCoords.filter(
+              (v, i) =>
+                i > 0 &&
+                !(
+                  v[0] === routeCoords[routeCoords.length - 1][0] &&
+                  v[1] === routeCoords[routeCoords.length - 1][1]
+                )
+            )
+          );
         } else {
           routeCoords = segCoords;
         }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.66.0
+Stable tag: 2.67.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.67.0 =
+* Driving routes no longer kink at chunk seams
 = 2.66.0 =
 * Driving routes no longer duplicate lines
 = 2.65.0 =


### PR DESCRIPTION
## Summary
- remove duplicated seam vertices in navigation
- bump plugin version to 2.67.0

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf25aff548327bc0a4a94f18b13c3