### PR TITLE
Fix nature path routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.72.0
+- Fix nature path route using only start, end and waypoint coordinates
 ### 2.71.0
 - Stats panel accounts for distance when deviating from the route
 ### 2.70.0
@@ -127,6 +129,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.72.0
+- Fix nature path route using only start, end and waypoint coordinates
 ### 2.71.0
 - Stats panel accounts for distance when deviating from the route
 ### 2.70.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.71.0
+Version: 2.72.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -297,7 +297,7 @@ document.addEventListener("DOMContentLoaded", function () {
     clearMap();
     log('Showing default route');
     coords = [];
-    gnMapData.locations.forEach((loc) => {
+    gnMapData.locations.forEach((loc, idx) => {
       const galleryHTML = loc.gallery && loc.gallery.length
         ? '<div class="gallery">' +
           loc.gallery.map(item => item.type === 'video'
@@ -314,7 +314,9 @@ document.addEventListener("DOMContentLoaded", function () {
           ${galleryHTML}
           ${uploadHTML}
         </div>`;
-      coords.push([loc.lng, loc.lat]);
+      if (loc.waypoint || idx === 0 || idx === gnMapData.locations.length - 1) {
+        coords.push([loc.lng, loc.lat]);
+      }
       if (!loc.waypoint) {
         const popup = new mapboxgl.Popup({ offset: 25 }).setHTML(popupHTML);
         const marker = new mapboxgl.Marker().setLngLat([loc.lng, loc.lat]).setPopup(popup).addTo(map);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.71.0
+Stable tag: 2.72.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.72.0 =
+* Nature path route uses only start, end and waypoint coordinates
 = 2.71.0 =
 * Distance, time and elevation stats now adjust when moving away from the route
 = 2.70.0 =


### PR DESCRIPTION
## Summary
- fix the default route to ignore points that aren't waypoints
- bump plugin version to 2.72.0

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68678c5eba348327969eb7537b982bcd