### PR TITLE
Bump plugin version to 2.73.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.73.0
+- No code changes; version bump
 ### 2.72.0
 - Fix nature path route using only start, end and waypoint coordinates
 - Nature Path is selected by default
@@ -130,6 +132,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.73.0
+- No code changes; version bump
 ### 2.72.0
 - Fix nature path route using only start, end and waypoint coordinates
 - Nature Path is selected by default

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.72.0
+Version: 2.73.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.72.0
+Stable tag: 2.73.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.73.0 =
+* No code changes; version bump
 = 2.72.0 =
 * Nature path route uses only start, end and waypoint coordinates
 * Nature Path selected by default


### PR DESCRIPTION
## Summary
- update plugin header version
- bump stable tag
- document version 2.73.0 in changelogs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68678e2c64a883278d5d34bd3b3501dd