### PR TITLE
Set walking mode as default

### DIFF
--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -12,7 +12,9 @@ document.addEventListener("DOMContentLoaded", function () {
   mapboxgl.accessToken = gnMapData.accessToken;
   const debugEnabled = gnMapData.debug === true;
   let coords = [];
-  let navigationMode = "driving";
+  // 'walking' keeps the route on the footpath
+  // try this default to see if it fixes multipath issues
+  let navigationMode = "walking";
   let map;
   let languageControl;
   let markers = [];


### PR DESCRIPTION
## Summary
- switch default navigation mode from driving to walking

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6867b147515c8327a738c546a80c71a4