### PR TITLE
Fix default route navigation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.75.0
+- Default route fetches directions using the selected navigation mode
 ### 2.74.0
 - No code changes; version bump
 ### 2.73.0
@@ -134,6 +136,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.75.0
+- Default route fetches directions using the selected navigation mode
 ### 2.74.0
 - No code changes; version bump
 ### 2.73.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.74.0
+Version: 2.75.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -326,7 +326,7 @@ document.addEventListener("DOMContentLoaded", function () {
       }
     });
     if (coords.length > 1) {
-      fetchDirections(coords).then(res => {
+      fetchDirections(coords, navigationMode).then(res => {
         if (!res.coordinates.length) {
           log('No coordinates returned for route');
           return;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.74.0
+Stable tag: 2.75.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.75.0 =
+* Default route fetches directions using the selected navigation mode
 = 2.74.0 =
 * No code changes; version bump
 = 2.73.0 =


### PR DESCRIPTION
## Summary
- ensure default route uses selected navigation mode
- bump plugin version to 2.75.0

## Testing
- `composer validate` *(fails: command not found)*
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b589324c8327a1edfa5c3a9db4ab