### PR TITLE
[Fix] limit nature path route to waypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.78.0
+- Fix nature path route using only start, end and waypoint coordinates
 ### 2.77.0
 - Nature path line uses all location posts in order
 ### 2.76.0
@@ -140,6 +142,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.78.0
+- Fix nature path route using only start, end and waypoint coordinates
 ### 2.77.0
 - Nature path line uses all location posts in order
 ### 2.76.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.77.0
+Version: 2.78.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -299,6 +299,7 @@ document.addEventListener("DOMContentLoaded", function () {
     clearMap();
     log('Showing default route');
     coords = [];
+    const lastIndex = gnMapData.locations.length - 1;
     gnMapData.locations.forEach((loc, idx) => {
       const galleryHTML = loc.gallery && loc.gallery.length
         ? '<div class="gallery">' +
@@ -316,7 +317,9 @@ document.addEventListener("DOMContentLoaded", function () {
           ${galleryHTML}
           ${uploadHTML}
         </div>`;
-      coords.push([loc.lng, loc.lat]);
+      if (idx === 0 || idx === lastIndex || loc.waypoint) {
+        coords.push([loc.lng, loc.lat]);
+      }
       if (!loc.waypoint) {
         const popup = new mapboxgl.Popup({ offset: 25 }).setHTML(popupHTML);
         const marker = new mapboxgl.Marker().setLngLat([loc.lng, loc.lat]).setPopup(popup).addTo(map);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.77.0
+Stable tag: 2.78.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.78.0 =
+* Fix nature path route using only start, end and waypoint coordinates
 = 2.77.0 =
 * Nature path line uses all location posts in order
 = 2.76.0 =


### PR DESCRIPTION
## Summary
- limit nature trail line to start/end and waypoint posts
- bump version to 2.78.0

## Testing
- `eslint js/mapbox-init.js` *(fails: ESLint couldn't find a configuration file)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868d09c5ab88327ac93be97706be788