### PR TITLE
[Fix] revert to walking mode and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
-### 2.79.0
-- Default navigation mode is now driving
+### 2.80.0
+- Default navigation mode reverted to walking
 ### 2.78.0
 - Fix nature path route using only start, end and waypoint coordinates
 ### 2.77.0
@@ -144,8 +144,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
-### 2.79.0
-- Default navigation mode is now driving
+### 2.80.0
+- Default navigation mode reverted to walking
 ### 2.78.0
 - Fix nature path route using only start, end and waypoint coordinates
 ### 2.77.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.79.0
+Version: 2.80.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -12,8 +12,9 @@ document.addEventListener("DOMContentLoaded", function () {
   mapboxgl.accessToken = gnMapData.accessToken;
   const debugEnabled = gnMapData.debug === true;
   let coords = [];
-  // Default mode now set to driving
-  let navigationMode = "driving";
+  // 'walking' keeps the route on the footpath
+  // try this default to see if it fixes multipath issues
+  let navigationMode = "walking";
   let map;
   let languageControl;
   let markers = [];

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.79.0
+Stable tag: 2.80.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,8 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
-= 2.79.0 =
-* Default navigation mode is now driving
+= 2.80.0 =
+* Default navigation mode reverted to walking
 = 2.78.0 =
 * Fix nature path route using only start, end and waypoint coordinates
 = 2.77.0 =


### PR DESCRIPTION
## Summary
- revert default navigation mode to walking
- bump plugin version to 2.80.0

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*
- `eslint js/mapbox-init.js` *(fails: missing configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6868d41694308327b6525cc90f14b654