### PR TITLE
[Fix] keep walking route for driving icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
-### 2.80.0
-- Default navigation mode reverted to walking
+### 2.81.0
+- Driving icon requests walking directions to avoid multi-route behavior
 ### 2.78.0
 - Fix nature path route using only start, end and waypoint coordinates
 ### 2.77.0
@@ -144,8 +144,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
-### 2.80.0
-- Default navigation mode reverted to walking
+### 2.81.0
+- Driving icon requests walking directions to avoid multi-route behavior
 ### 2.78.0
 - Fix nature path route using only start, end and waypoint coordinates
 ### 2.77.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.80.0
+Version: 2.81.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -402,10 +402,15 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   window.setMode = function (mode) {
-    navigationMode = mode;
     const sel = document.getElementById("gn-mode-select");
     if (sel) sel.value = mode;
-    log("Navigation mode set to:", mode);
+    navigationMode = mode === 'driving' ? 'walking' : mode;
+    log(
+      "Navigation mode icon:",
+      mode,
+      "using actual mode:",
+      navigationMode
+    );
   };
 
   async function getElevationGain(points) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.80.0
+Stable tag: 2.81.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,8 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
-= 2.80.0 =
-* Default navigation mode reverted to walking
+= 2.81.0 =
+* Driving icon requests walking directions to avoid multi-route behavior
 = 2.78.0 =
 * Fix nature path route using only start, end and waypoint coordinates
 = 2.77.0 =


### PR DESCRIPTION
## Summary
- keep walking mode under the hood when selecting the driving icon
- bump plugin version to 2.81.0
- update changelog entries

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*
- `eslint js --ext .js` *(fails: missing ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6868d60990c8832799a2f2eae68311ac