### PR TITLE
[Feature] default driving mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.82.0
+- Driving mode selected by default
 ### 2.81.0
 - Driving icon requests walking directions to avoid multi-route behavior
 ### 2.78.0
@@ -144,6 +146,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.82.0
+- Driving mode selected by default
 ### 2.81.0
 - Driving icon requests walking directions to avoid multi-route behavior
 ### 2.78.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.81.0
+Version: 2.82.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -12,9 +12,8 @@ document.addEventListener("DOMContentLoaded", function () {
   mapboxgl.accessToken = gnMapData.accessToken;
   const debugEnabled = gnMapData.debug === true;
   let coords = [];
-  // 'walking' keeps the route on the footpath
-  // try this default to see if it fixes multipath issues
-  let navigationMode = "walking";
+  // driving mode provides the most direct route by default
+  let navigationMode = "driving";
   let map;
   let languageControl;
   let markers = [];
@@ -404,7 +403,7 @@ document.addEventListener("DOMContentLoaded", function () {
   window.setMode = function (mode) {
     const sel = document.getElementById("gn-mode-select");
     if (sel) sel.value = mode;
-    navigationMode = mode === 'driving' ? 'walking' : mode;
+    navigationMode = mode;
     log(
       "Navigation mode icon:",
       mode,

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.81.0
+Stable tag: 2.82.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.82.0 =
+* Driving mode selected by default
 = 2.81.0 =
 * Driving icon requests walking directions to avoid multi-route behavior
 = 2.78.0 =


### PR DESCRIPTION
## Summary
- set driving mode as the default
- keep selected mode when toggling between navigation types
- bump plugin version to 2.82.0 and update docs

## Testing
- `php -l gn-mapbox-plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_6868d7aa578c8327a6bffcfc3ef62c00