### PR TITLE
[Fix] default to walking mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.83.0
+- Driving icon remains selected but walking directions are used by default
 ### 2.82.0
 - Driving mode selected by default
 ### 2.81.0
@@ -146,6 +148,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.83.0
+- Driving icon remains selected but walking directions are used by default
 ### 2.82.0
 - Driving mode selected by default
 ### 2.81.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.82.0
+Version: 2.83.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -12,8 +12,8 @@ document.addEventListener("DOMContentLoaded", function () {
   mapboxgl.accessToken = gnMapData.accessToken;
   const debugEnabled = gnMapData.debug === true;
   let coords = [];
-  // driving mode provides the most direct route by default
-  let navigationMode = "driving";
+  // default icon shows driving but we actually request walking directions
+  let navigationMode = "walking";
   let map;
   let languageControl;
   let markers = [];
@@ -177,7 +177,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }
     const modeSel = navPanel.querySelector("#gn-mode-select");
     if (modeSel) {
-      modeSel.value = navigationMode;
+      modeSel.value = 'driving';
       modeSel.onchange = () => setMode(modeSel.value);
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.82.0
+Stable tag: 2.83.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.83.0 =
+* Driving icon remains selected but walking directions are used by default
 = 2.82.0 =
 * Driving mode selected by default
 = 2.81.0 =


### PR DESCRIPTION
## Summary
- default directions use walking mode while driving icon stays selected
- bump plugin version to 2.83.0

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*
- `npx eslint js/mapbox-init.js` *(fails: missing ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6868d96debfc8327b7768941ba750e76