### PR TITLE
[Fix] draw route directly and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.84.0
+- Route line drawn using direct coordinates
 ### 2.83.0
 - Driving icon remains selected but walking directions are used by default
 ### 2.82.0
@@ -148,6 +150,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.84.0
+- Route line drawn using direct coordinates
 ### 2.83.0
 - Driving icon remains selected but walking directions are used by default
 ### 2.82.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.83.0
+Version: 2.84.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -326,16 +326,22 @@ document.addEventListener("DOMContentLoaded", function () {
       }
     });
     if (coords.length > 1) {
-      fetchDirections(coords, navigationMode).then(res => {
-        if (!res.coordinates.length) {
-          log('No coordinates returned for route');
-          return;
+      const routeGeoJson = {
+        type: 'Feature',
+        geometry: {
+          type: 'LineString',
+          coordinates: coords
         }
-        const routeGeoJson = { type: 'Feature', geometry: { type: 'LineString', coordinates: res.coordinates } };
-        map.addSource('route', { type: 'geojson', data: routeGeoJson });
-        map.addLayer({ id: 'route', type: 'line', source: 'route', layout: { 'line-join': 'round', 'line-cap': 'round' }, paint: { 'line-color': '#ff0000', 'line-width': 4 } });
-        log('Route line drawn with', res.coordinates.length, 'points');
+      };
+      map.addSource('route', { type: 'geojson', data: routeGeoJson });
+      map.addLayer({
+        id: 'route',
+        type: 'line',
+        source: 'route',
+        layout: { 'line-join': 'round', 'line-cap': 'round' },
+        paint: { 'line-color': '#ff0000', 'line-width': 4 }
       });
+      log('Route line drawn using direct coordinates:', coords.length);
     } else {
       log('Not enough coordinates for route line');
     }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.83.0
+Stable tag: 2.84.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.84.0 =
+* Route line drawn using direct coordinates
 = 2.83.0 =
 * Driving icon remains selected but walking directions are used by default
 = 2.82.0 =


### PR DESCRIPTION
## Summary
- remove Directions API usage in default route
- draw default route directly from coordinates
- bump plugin version to 2.84.0
- document new version in changelogs

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*
- `eslint js` *(fails: missing eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_6868e37695548327bf8b4b70fe2416fa