### PR TITLE
[Feature] Bump version and confirm 14-point nature path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.87.0
+- Nature path uses 14 non-waypoint locations
+
+
 ### 2.86.0
 - Route drawn using LineString from 14 non-waypoint locations
 ### 2.85.0
@@ -154,6 +158,9 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.87.0
+- Nature path uses 14 non-waypoint locations
+
 ### 2.86.0
 - Route drawn using LineString from 14 non-waypoint locations
 ### 2.85.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.86.0
+Version: 2.87.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.86.0
+Stable tag: 2.87.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,11 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.87.0 =
+* Nature path uses 14 non-waypoint locations
+= 2.86.0 =
+* Route drawn using LineString from 14 non-waypoint locations
+
 = 2.85.0 =
 * Route drawn using manual LineString with 31 coordinates
 = 2.84.0 =


### PR DESCRIPTION
## Summary
- bump plugin version to 2.87.0
- document that the Nature Path uses 14 non-waypoint coordinates

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: php not installed)*
- `npx eslint js` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_686a1f4d81c48327a76257826384d735