### PR TITLE
[Fix] bump plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
-### 2.88.0
+### 2.89.0
 - Nature path uses 14 non-waypoint locations
 
 
@@ -158,7 +158,7 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
-### 2.88.0
+### 2.89.0
 - Nature path uses 14 non-waypoint locations
 
 ### 2.86.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.88.0
+Version: 2.89.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.88.0
+Stable tag: 2.89.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,7 +40,7 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
-= 2.88.0 =
+= 2.89.0 =
 * Nature path uses 14 non-waypoint locations
 = 2.86.0 =
 * Route drawn using LineString from 14 non-waypoint locations


### PR DESCRIPTION
## Summary
- bump plugin version to 2.89.0

## Testing
- `php -l gn-mapbox-plugin.php`
- `eslint js/*.js` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_686a257231188327be6f16b28ed0040c