### PR TITLE
[Fix] ensure default route closes and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
-### 2.90.0
-- Default dataset closes the loop by repeating the starting location
+### 2.91.0
+- Default route expects 15 coordinates and loop closes properly
 
 
 ### 2.86.0
@@ -158,8 +158,11 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.91.0
+- Default route expects 15 coordinates and loop closes properly
+
 ### 2.90.0
-- Default dataset closes the loop by repeating the starting location
+* Default dataset closes the loop by repeating the starting location
 
 ### 2.86.0
 - Route drawn using LineString from 14 non-waypoint locations

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.90.0
+Version: 2.91.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -301,8 +301,8 @@ document.addEventListener("DOMContentLoaded", function () {
     coords = gnMapData.locations
       .filter(loc => !loc.waypoint)
       .map(loc => [loc.lng, loc.lat]);
-    if (coords.length !== 14) {
-      log('Expected 14 coordinates but got', coords.length);
+    if (coords.length !== 15) {
+      log('Expected 15 coordinates but got', coords.length);
     }
     gnMapData.locations.forEach(loc => {
       const galleryHTML = loc.gallery && loc.gallery.length

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.90.0
+Stable tag: 2.91.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.91.0 =
+* Default route expects 15 coordinates and loop closes properly
 = 2.90.0 =
 * Default dataset closes the loop by repeating the starting location
 = 2.86.0 =


### PR DESCRIPTION
## Summary
- ensure the default route check expects 15 coordinates
- bump plugin version to 2.91.0
- update stable tag and changelogs

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*
- `npx eslint js/mapbox-init.js` *(fails: no ESLint config found)*

------
https://chatgpt.com/codex/tasks/task_e_686a2a8c344c8327a9f64fcf167884db