### PR TITLE
[Fix] import all 15 default locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.93.0
+- Import all 15 default locations without skipping duplicates
+
 ### 2.92.0
 - Default route expects 15 coordinates and loop closes properly
 
@@ -158,6 +161,9 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.93.0
+- Import all 15 default locations without skipping duplicates
+
 ### 2.92.0
 - Default route expects 15 coordinates and loop closes properly
 

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.92.0
+Version: 2.93.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -65,6 +65,23 @@ function gn_location_exists($title, $lat = null, $lng = null) {
     return false;
 }
 
+function gn_location_order_exists($index) {
+    $query = new WP_Query([
+        'post_type'      => 'map_location',
+        'posts_per_page' => 1,
+        'fields'         => 'ids',
+        'meta_query'     => [
+            [
+                'key'   => '_gn_location_order',
+                'value' => $index,
+            ],
+        ],
+    ]);
+    $exists = $query->have_posts();
+    wp_reset_postdata();
+    return $exists;
+}
+
 function gn_import_default_locations() {
     $json_file = plugin_dir_path(__FILE__) . 'data/locations.json';
     if (!file_exists($json_file)) {
@@ -82,11 +99,12 @@ function gn_import_default_locations() {
             continue;
         }
 
-        $lat = $location['lat'] ?? null;
-        $lng = $location['lng'] ?? null;
-        if (gn_location_exists($location['title'], $lat, $lng)) {
+        if (gn_location_order_exists($index)) {
             continue;
         }
+
+        $lat = $location['lat'] ?? null;
+        $lng = $location['lng'] ?? null;
 
         $post_id = wp_insert_post([
             'post_title'   => wp_strip_all_tags($location['title']),

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.92.0
+Stable tag: 2.93.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.93.0 =
+* Import all 15 default locations without skipping duplicates
 = 2.92.0 =
 * Default route expects 15 coordinates and loop closes properly
 = 2.90.0 =


### PR DESCRIPTION
## Summary
- ensure default location import checks order meta so no entries are skipped
- bump plugin version to 2.93.0
- document new version in README files

## Testing
- `php -l gn-mapbox-plugin.php`
- `npx eslint .` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686a2e6bf98083279b6506ac7fd5e499