### PR TITLE
[Fix] reposition WP2.1 and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.109.0
+- Repositioned WP2.1 closer to the road
 ### 2.108.0
 - Add waypoint near Βρύση Καραμάνα to keep route straight
 ### 2.107.0
@@ -195,6 +197,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.109.0
+- Repositioned WP2.1 closer to the road
 ### 2.108.0
 - Add waypoint near Βρύση Καραμάνα to keep route straight
 ### 2.107.0

--- a/data/locations.json
+++ b/data/locations.json
@@ -127,8 +127,8 @@
     "content": "",
     "image": null,
     "gallery": [],
-    "lat": 34.974207,
-    "lng": 32.375823,
+    "lat": 34.97417,
+    "lng": 32.37595,
     "waypoint": true
   },
   {

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.108.0
+Version: 2.109.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.108.0
+Stable tag: 2.109.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- move WP2.1 coordinates closer to the road
- bump plugin version to 2.109.0
- document new version in readmes

## Testing
- `php -l gn-mapbox-plugin.php`
- `npx eslint js` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_686a786c5c488327ad8c2a51a25e30ef