### PR TITLE
[Fix] adjust WP2.2 waypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.111.0
+- Move WP2.2 before Βρύση Καραμάνα to stay on straight road
+
 ### 2.110.0
 - Adjust WP2.1 so Βρύση Καραμάνα uses the straight road
 ### 2.109.0
@@ -199,6 +202,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.111.0
+- Move WP2.2 before Βρύση Καραμάνα for a straight route
 ### 2.110.0
 - Adjust WP2.1 so Βρύση Καραμάνα uses the straight road
 ### 2.109.0

--- a/data/locations.json
+++ b/data/locations.json
@@ -102,8 +102,8 @@
     "content": "",
     "image": null,
     "gallery": [],
-    "lat": 34.982158,
-    "lng": 32.375981,
+    "lat": 34.98361111,
+    "lng": 32.37596667,
     "waypoint": true
   },
   {

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.110.0
+Version: 2.111.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.110.0
+Stable tag: 2.111.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- move WP2.2 waypoint so the road before Βρύση Καραμάνα stays straight
- bump plugin version to 2.111.0

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*
- `eslint js` *(fails: couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686a7ed0ce40832796e11b33667c2d24