### PR TITLE
[Fix] adjust WP2 waypoints for straight path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.112.0
+- Set WP2.1 and WP2.2 to keep going straight after Θέα προς Κόλπους Λάρας (Κιόσκι Πιττοκόπου) with no turning
+
 ### 2.111.0
 - Move WP2.2 before Βρύση Καραμάνα to stay on straight road
 
@@ -202,6 +205,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
+### 2.112.0
+- Set WP2.1 and WP2.2 to keep going straight after Θέα προς Κόλπους Λάρας (Κιόσκι Πιττοκόπου) with no turning
 ### 2.111.0
 - Move WP2.2 before Βρύση Καραμάνα for a straight route
 ### 2.110.0

--- a/data/locations.json
+++ b/data/locations.json
@@ -102,8 +102,8 @@
     "content": "",
     "image": null,
     "gallery": [],
-    "lat": 34.98361111,
-    "lng": 32.37596667,
+    "lat": 34.98477542,
+    "lng": 32.37610784,
     "waypoint": true
   },
   {
@@ -127,8 +127,8 @@
     "content": "",
     "image": null,
     "gallery": [],
-    "lat": 34.97438889,
-    "lng": 32.37572222,
+    "lat": 34.97463605,
+    "lng": 32.37487849,
     "waypoint": true
   },
   {

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.111.0
+Version: 2.112.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.111.0
+Stable tag: 2.112.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- align WP2.1 and WP2.2 waypoints so the route continues straight after the Kiosk viewpoint
- update plugin version to 2.112.0
- document the change in README

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686a8240be008327b8a460d9d388f2af