### PR TITLE
[Fix] revert dataset and show waypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
-### 2.117.0
-- Adjust WP2.1, WP2.2 and WP3.1 coordinates for smoother routing
+### 2.118.0
+- Make WP2.1, WP2.2 and WP3.1 visible for debugging
 ### 2.116.0
 - Add waypoints WP2.1, WP2.2 and WP3.1
 ### 2.115.0
@@ -197,8 +197,8 @@ at runtime, those locations are also created as posts so all features keep
 working. Update this file to change the built-in locations.
 
 ## Changelog
-### 2.117.0
-- Adjust WP2.1, WP2.2 and WP3.1 coordinates for smoother routing
+### 2.118.0
+- Make WP2.1, WP2.2 and WP3.1 visible for debugging
 ### 2.116.0
 - Add waypoints WP2.1, WP2.2 and WP3.1
 ### 2.115.0

--- a/data/locations.json
+++ b/data/locations.json
@@ -110,18 +110,16 @@
     "content": "",
     "image": null,
     "gallery": [],
-    "lat": 34.977300,
-    "lng": 32.375900,
-    "waypoint": true
+    "lat": 34.977087,
+    "lng": 32.375209
   },
   {
     "title": "WP2.2",
     "content": "",
     "image": null,
     "gallery": [],
-    "lat": 34.983900,
-    "lng": 32.377000,
-    "waypoint": true
+    "lat": 34.984638,
+    "lng": 32.377496
   },
   {
     "title": "Θέα προς Κόλπους Λάρας (Κιόσκι Πιττοκόπου)",
@@ -144,9 +142,8 @@
     "content": "",
     "image": null,
     "gallery": [],
-    "lat": 34.960700,
-    "lng": 32.398000,
-    "waypoint": true
+    "lat": 34.960465,
+    "lng": 32.398292
   },
   {
     "title": "Ιερό Εξωκλήσι Αποστόλου Λουκά",

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.117.0
+Version: 2.118.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.117.0
+Stable tag: 2.118.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- revert waypoint coordinates to version 2.116.0
- make WP2.1, WP2.2 and WP3.1 visible for debugging
- bump plugin version to 2.118.0
- update changelog

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab83415e48327b640a9c4646e958b