### PR TITLE
[Fix] persistent popups and icon markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.120.0
+- Keep popups open on hover until closed
+- Restore location-style marker icons
 ### 2.119.0
 - Show popups on marker hover and update icon styling
 ### 2.118.0

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -243,17 +243,7 @@
 }
 
 /* === Custom Markers === */
-.gn-marker {
-  width: 24px;
-  height: 24px;
-  background-color: #007cbf;
-  border-radius: 50%;
-  cursor: pointer;
-}
-
-.gn-marker.hover {
-  background-color: #005f91;
-}
+/* Default Mapbox marker icons are used. */
 
 /* === Description Toggle === */
 .gn-desc-label {

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.119.0
+Version: 2.120.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -336,21 +336,17 @@ document.addEventListener("DOMContentLoaded", function () {
         </div>`;
       if (!loc.waypoint) {
         const popup = new mapboxgl.Popup({ offset: 25 }).setHTML(popupHTML);
-        const el = document.createElement('div');
-        el.className = 'gn-marker';
-        const marker = new mapboxgl.Marker({ element: el, anchor: 'bottom' })
+        const marker = new mapboxgl.Marker()
           .setLngLat([loc.lng, loc.lat])
           .addTo(map);
+        const el = marker.getElement();
         el.addEventListener('mouseenter', () => {
-          el.classList.add('hover');
+          popups.forEach(p => p.remove());
+          popups = [];
           popup.setLngLat([loc.lng, loc.lat]).addTo(map);
-        });
-        el.addEventListener('mouseleave', () => {
-          el.classList.remove('hover');
-          popup.remove();
+          popups.push(popup);
         });
         markers.push(marker);
-        popups.push(popup);
       }
     });
     if (coords.length > 1) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.119.0
+Stable tag: 2.120.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- keep marker popups visible until closed
- revert to default location icons for markers
- bump plugin version to 2.120.0

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*
- `npx eslint js/mapbox-init.js` *(fails: could not find config)*

------
https://chatgpt.com/codex/tasks/task_e_686abe6ddb0c8327a9560a301b3072dc