### PR TITLE
[Feature] Add route debug helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.121.1
+- Add `gnDebugPath` console function for inspecting route creation
 ### 2.121.0
 - Fix duplicate straight route near Πιττοκόπος
 ### 2.120.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.121.0
+Version: 2.121.1
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -537,6 +537,28 @@ document.addEventListener("DOMContentLoaded", function () {
     return { coordinates: routeCoords, steps, distance, duration };
   }
 
+  const gnDebugPath = async (
+    points = coords,
+    mode = navigationMode,
+    lang = getSelectedLanguage()
+  ) => {
+    console.log('[GN DEBUG]', 'Debugging path');
+    console.log('[GN DEBUG]', 'Waypoints:', points);
+    console.log('[GN DEBUG]', 'Mode:', mode, 'Lang:', lang);
+    const result = await fetchDirections(points, mode, true, lang);
+    console.log('[GN DEBUG]', 'Total distance', result.distance, 'm');
+    console.log('[GN DEBUG]', 'Total duration', result.duration, 'sec');
+    result.steps.forEach((step, i) => {
+      const m = step.maneuver;
+      console.log(
+        '[GN DEBUG]',
+        `Step ${i + 1}: ${m.instruction} (type: ${m.type}, modifier: ${m.modifier || 'none'})`
+      );
+    });
+    return result;
+  };
+  window.gnDebugPath = gnDebugPath;
+
   async function startNavigation() {
     if (!navigator.geolocation) {
       log("Geolocation not supported.");

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.121.0
+Stable tag: 2.121.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.121.1 =
+* Add `gnDebugPath` console function for inspecting route creation
 = 2.121.0 =
 * Fix duplicate straight route near Πιττοκόπος
 = 2.95.0 =


### PR DESCRIPTION
## Summary
- expose `gnDebugPath` for console route inspection
- bump plugin version to 2.121.1

## Testing
- `eslint js/mapbox-init.js` *(fails: ESLint couldn't find a config)*
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac7a1525883279b5d90353bde1f59