### PR TITLE
[Feature] Bearing debug updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.128.0
+- Added `gnDebugBearings` function to log segment bearings in the console
 ### 2.127.0
 - Apply bearings to all coordinates for more accurate routing
 

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.127.0
+Version: 2.128.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -630,6 +630,24 @@ document.addEventListener("DOMContentLoaded", function () {
   };
   window.gnDebugPath = gnDebugPath;
 
+  const gnDebugBearings = (points = coords) => {
+    if (!Array.isArray(points) || points.length < 2) {
+      console.log('[GN DEBUG]', 'Need at least two points to compute bearings');
+      return;
+    }
+    console.log('[GN DEBUG]', 'Bearings between waypoints:');
+    for (let i = 0; i < points.length - 1; i++) {
+      const start = points[i];
+      const end = points[i + 1];
+      const ang = Math.round(bearingBetween(start, end));
+      console.log(
+        '[GN DEBUG]',
+        `Waypoint ${i} (${start.join(',')}) -> Waypoint ${i + 1} (${end.join(',')}): ${ang}\u00B0`
+      );
+    }
+  };
+  window.gnDebugBearings = gnDebugBearings;
+
   async function startNavigation() {
     if (!navigator.geolocation) {
       log("Geolocation not supported.");

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.127.0
+Stable tag: 2.128.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.128.0
+* Add `gnDebugBearings` console utility to inspect segment bearings
 = 2.127.0
 * Apply bearings to all coordinates for accurate routing
 = 2.126.0


### PR DESCRIPTION
## Summary
- add `gnDebugBearings` console function
- bump plugin version to 2.128.0
- document new debugging utility in README and readme.txt

## Testing
- `npx eslint js/mapbox-init.js` *(fails: ESLint config missing)*
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be7134f148327b3426d3d39048b73