### PR TITLE
[Feature] Improve debug bearings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.129.0
+- `gnDebugBearings` now reports LEFT, RIGHT or STRAIGHT for each turn
 ### 2.128.0
 - Added `gnDebugBearings` function to log segment bearings in the console
 ### 2.127.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.128.0
+Version: 2.129.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -630,20 +630,31 @@ document.addEventListener("DOMContentLoaded", function () {
   };
   window.gnDebugPath = gnDebugPath;
 
-  const gnDebugBearings = (points = coords) => {
+  const gnDebugBearings = (points = coords, threshold = 15) => {
     if (!Array.isArray(points) || points.length < 2) {
       console.log('[GN DEBUG]', 'Need at least two points to compute bearings');
       return;
     }
     console.log('[GN DEBUG]', 'Bearings between waypoints:');
+    let prev = null;
     for (let i = 0; i < points.length - 1; i++) {
       const start = points[i];
       const end = points[i + 1];
       const ang = Math.round(bearingBetween(start, end));
-      console.log(
-        '[GN DEBUG]',
-        `Waypoint ${i} (${start.join(',')}) -> Waypoint ${i + 1} (${end.join(',')}): ${ang}\u00B0`
-      );
+      let turn = '';
+      if (prev !== null) {
+        let diff = ((ang - prev + 540) % 360) - 180;
+        if (Math.abs(diff) < threshold) {
+          turn = 'STRAIGHT';
+        } else if (diff > 0) {
+          turn = 'RIGHT';
+        } else {
+          turn = 'LEFT';
+        }
+        turn = ` (${turn})`;
+      }
+      console.log('[GN DEBUG]', `Waypoint ${i} (${start.join(',')}) -> Waypoint ${i + 1} (${end.join(',')}); ${ang}\u00B0${turn}`);
+      prev = ang;
     }
   };
   window.gnDebugBearings = gnDebugBearings;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.128.0
+Stable tag: 2.129.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.129.0
+* `gnDebugBearings` now reports LEFT, RIGHT or STRAIGHT for each turn
 = 2.128.0
 * Add `gnDebugBearings` console utility to inspect segment bearings
 = 2.127.0


### PR DESCRIPTION
## Summary
- improve `gnDebugBearings` to report LEFT/RIGHT/STRAIGHT
- bump plugin version to 2.129.0

## Testing
- `npx eslint js/mapbox-init.js`
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be9c6e3788327ac6e67a95d3913a1