### PR TITLE
[Fix] remove WP20.3 waypoint and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.134.0
+- Removed waypoint WP20.3 between points 20 and 21
+
 ### 2.133.0
 - Added waypoints WP20.1 to WP20.6 between points 20 and 21
 

--- a/data/locations.json
+++ b/data/locations.json
@@ -193,15 +193,6 @@
     "waypoint": true
   },
   {
-    "title": "WP20.3",
-    "content": "",
-    "image": null,
-    "gallery": [],
-    "lat": 34.961656,
-    "lng": 32.396996,
-    "waypoint": true
-  },
-  {
     "title": "WP20.4",
     "content": "",
     "image": null,

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.133.0
+Version: 2.134.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.133.0
+Stable tag: 2.134.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.134.0
+* Removed waypoint WP20.3 between points 20 and 21
 = 2.133.0
 * Added waypoints WP20.1 to WP20.6 between points 20 and 21
 = 2.132.0


### PR DESCRIPTION
## Summary
- remove unused waypoint `WP20.3`
- bump plugin version to 2.134.0
- document change in README and readme.txt

## Testing
- `php -l gn-mapbox-plugin.php`
- `jq '.' data/locations.json`

------
https://chatgpt.com/codex/tasks/task_e_686c024fd570832797ad5da7e5d51941