### PR TITLE
[Fix] improve navigation icons and popups

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.136.0
+- Improve tracker icons and popup interactions
 ### 2.135.0
 - Updated marker interactions and navigation interface
 ### 2.134.0

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -313,3 +313,9 @@
   display: none;
   margin-top: 5px;
 }
+
+/* === Marker Hover === */
+.gn-marker:hover,
+.gn-marker.gn-active {
+  filter: brightness(85%);
+}

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.135.0
+Version: 2.136.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -277,6 +277,10 @@ document.addEventListener("DOMContentLoaded", function () {
     markers = [];
     popups.forEach(p => p.remove());
     popups = [];
+    if (activeMarker) {
+      activeMarker.getElement().classList.remove('gn-active');
+      activeMarker = null;
+    }
     const sources = ['route', 'route-tracker', 'trail-line', 'nav-route'];
     const layers = ['route', 'route-tracker', 'trail-line', 'nav-route'];
     layers.forEach(l => { if (map.getLayer(l)) map.removeLayer(l); });
@@ -342,28 +346,27 @@ document.addEventListener("DOMContentLoaded", function () {
         </div>`;
       if (!loc.waypoint) {
         const popup = new mapboxgl.Popup({ offset: 25 }).setHTML(popupHTML);
-        const marker = new mapboxgl.Marker()
+        const marker = new mapboxgl.Marker({ color: '#3FB1CE' })
           .setLngLat([loc.lng, loc.lat])
           .addTo(map);
         const el = marker.getElement();
-        el.style.backgroundColor = '#3FB1CE';
+        el.classList.add('gn-marker');
         const showPopup = () => {
           if (activeMarker) {
-            activeMarker.getElement().style.backgroundColor = '#3FB1CE';
+            activeMarker.getElement().classList.remove('gn-active');
           }
           activeMarker = marker;
-          el.style.backgroundColor = '#002D44';
+          el.classList.add('gn-active');
           popups.forEach(p => p.remove());
           popups = [];
           popup.setLngLat([loc.lng, loc.lat]).addTo(map);
           popups.push(popup);
         };
-        if (window.innerWidth <= 768) {
-          el.addEventListener('click', showPopup);
-        } else {
+        el.addEventListener('click', showPopup);
+        if (window.innerWidth > 768) {
           el.addEventListener('mouseenter', showPopup);
           el.addEventListener('mouseleave', () => {
-            el.style.backgroundColor = '#3FB1CE';
+            el.classList.remove('gn-active');
           });
         }
         markers.push(marker);
@@ -836,7 +839,12 @@ document.addEventListener("DOMContentLoaded", function () {
         id: 'route-tracker',
         type: 'symbol',
         source: 'route-tracker',
-        layout: { 'icon-image': iconMap[navigationMode], 'icon-size': 1.5 }
+        layout: {
+          'icon-image': iconMap[navigationMode],
+          'icon-size': 1.5,
+          'icon-allow-overlap': true,
+          'icon-ignore-placement': true
+        }
       });
     } else {
       map.getSource('route-tracker').setData({
@@ -844,6 +852,8 @@ document.addEventListener("DOMContentLoaded", function () {
         geometry: { type: 'Point', coordinates: coord }
       });
       map.setLayoutProperty('route-tracker', 'icon-image', iconMap[navigationMode]);
+      map.setLayoutProperty('route-tracker', 'icon-allow-overlap', true);
+      map.setLayoutProperty('route-tracker', 'icon-ignore-placement', true);
     }
 
     if (!map.getSource('trail-line')) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.135.0
+Stable tag: 2.136.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.136.0
+* Improve tracker icons and popup interactions
 = 2.135.0
 * Update marker interactions and navigation UI
 = 2.134.0


### PR DESCRIPTION
## Summary
- tweak popup interaction and tracker icon overlap
- add hover style for markers
- bump plugin version to 2.136.0

## Testing
- `eslint js/mapbox-init.js` *(fails: ESLint couldn't find config)*
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c28d6b10c83279c565e3f11796648