### PR TITLE
[Fix] improve mobile popups and routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Create `Map Location` posts with latitude and longitude fields and place the `[g
 
 ### 2.136.0
 - Improve tracker icons and popup interactions
+### 2.137.0
+- Fix mobile popups and correct driving route endpoints
 ### 2.135.0
 - Updated marker interactions and navigation interface
 ### 2.134.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.136.0
+Version: 2.137.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -993,7 +993,7 @@ function gn_mapbox_drousia_to_polis_shortcode() {
 }
 add_shortcode('gn_mapbox_drousia_polis', 'gn_mapbox_drousia_to_polis_shortcode');
 
-// Paphos to Paphos Airport (reversed to show directions from the airport to Paphos)
+// Paphos Airport to Drouseia
 function gn_mapbox_paphos_to_airport_shortcode() {
     if (!get_option('gn_mapbox_token')) {
         return '<p class="gn-mapbox-error">' . esc_html__('Mapbox access token missing. Set one under Settings → GN Mapbox.', 'gn-mapbox') . '</p>';
@@ -1021,7 +1021,7 @@ function gn_mapbox_paphos_to_airport_shortcode() {
         mapPA.addControl(directionsPA, 'top-left');
         mapPA.on('load', function() {
             directionsPA.setOrigin([32.4858, 34.7174]);
-            directionsPA.setDestination([32.4297, 34.7753]);
+            directionsPA.setDestination([32.3975751, 34.9627965]);
         });
     });
     </script>

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -363,6 +363,7 @@ document.addEventListener("DOMContentLoaded", function () {
           popups.push(popup);
         };
         el.addEventListener('click', showPopup);
+        el.addEventListener('touchstart', showPopup);
         if (window.innerWidth > 768) {
           el.addEventListener('mouseenter', showPopup);
           el.addEventListener('mouseleave', () => {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.136.0
+Stable tag: 2.137.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.137.0
+* Fix mobile popups and correct driving route endpoints
 = 2.136.0
 * Improve tracker icons and popup interactions
 = 2.135.0


### PR DESCRIPTION
## Summary
- update marker popup click for touch events
- correct airport route destination
- bump plugin version to 2.137.0

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*
- `npx eslint js/mapbox-init.js` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c2d170fa48327bb56c66be7b559a2