### PR TITLE
[Fix] revert plugin to 2.134.0 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
-### 2.136.0
-- Improve tracker icons and popup interactions
-### 2.137.0
-- Fix mobile popups and correct driving route endpoints
-### 2.135.0
-- Updated marker interactions and navigation interface
+### 2.138.0
+- Reverted plugin to version 2.134.0 state
+
 ### 2.134.0
 - Removed waypoint WP20.3 between points 20 and 21
 

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -112,50 +112,12 @@
   display: none;
 }
 
-/* Navigation panel base */
-#gn-nav-panel {
-  position: fixed;
-  top: 100px;
-  left: 10px;
-  width: 50%;
-  max-width: 400px;
-  z-index: 9998;
-  border-radius: 8px;
-  border: 1px solid #ccc;
-  box-shadow: 0 2px 5px rgba(0,0,0,0.3);
-  background: #fff;
-  font-family: sans-serif;
-}
-
-.gn-nav-header {
-  cursor: move;
-  background: #002d44;
-  color: #fff;
-  padding: 4px;
-  font-size: 13px;
-}
-
-#gn-close-nav {
-  float: right;
-  background: none;
-  border: none;
-  color: #fff;
-  font-size: 16px;
-  cursor: pointer;
-}
-
-
-.gn-nav-content {
-  padding: 6px;
-}
-
 /* Navigation panel override for mobile */
 @media (max-width: 767px) {
   #gn-nav-panel {
-    width: 100% !important;
-    left: 0 !important;
-    top: auto !important;
-    bottom: 0;
+    width: 110px !important;
+    left: 5vw !important;
+    top: 10vh !important;
   }
   #gn-debug-panel {
     width: 300px !important;
@@ -185,21 +147,6 @@
   width: 100%;
   padding: 4px 6px;
   font-size: 13px;
-}
-
-.gn-nav-row {
-  display: grid;
-  gap: 4px;
-}
-
-.gn-nav-select-row {
-  grid-template-columns: repeat(3, 1fr);
-  margin-bottom: 4px;
-}
-
-.gn-nav-btn-row {
-  grid-template-columns: repeat(2, 1fr);
-  margin-bottom: 4px;
 }
 
 #gn-route-select {
@@ -286,15 +233,12 @@
 
 #gn-open-nav {
   position: fixed;
-  top: 100px;
-  left: 10px;
   background-color: #007cbf;
   color: #fff;
   border: none;
   cursor: pointer;
   z-index: 9998;
   width: 30px;
-  display: none;
   padding: 4px;
 }
 
@@ -312,10 +256,4 @@
 .gn-desc-content {
   display: none;
   margin-top: 5px;
-}
-
-/* === Marker Hover === */
-.gn-marker:hover,
-.gn-marker.gn-active {
-  filter: brightness(85%);
 }

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.137.0
+Version: 2.138.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -993,7 +993,7 @@ function gn_mapbox_drousia_to_polis_shortcode() {
 }
 add_shortcode('gn_mapbox_drousia_polis', 'gn_mapbox_drousia_to_polis_shortcode');
 
-// Paphos Airport to Drouseia
+// Paphos to Paphos Airport (reversed to show directions from the airport to Paphos)
 function gn_mapbox_paphos_to_airport_shortcode() {
     if (!get_option('gn_mapbox_token')) {
         return '<p class="gn-mapbox-error">' . esc_html__('Mapbox access token missing. Set one under Settings → GN Mapbox.', 'gn-mapbox') . '</p>';
@@ -1021,7 +1021,7 @@ function gn_mapbox_paphos_to_airport_shortcode() {
         mapPA.addControl(directionsPA, 'top-left');
         mapPA.on('load', function() {
             directionsPA.setOrigin([32.4858, 34.7174]);
-            directionsPA.setDestination([32.3975751, 34.9627965]);
+            directionsPA.setDestination([32.4297, 34.7753]);
         });
     });
     </script>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.137.0
+Stable tag: 2.138.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,12 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
-= 2.137.0
-* Fix mobile popups and correct driving route endpoints
-= 2.136.0
-* Improve tracker icons and popup interactions
-= 2.135.0
-* Update marker interactions and navigation UI
+= 2.138.0
+* Reverted plugin to version 2.134.0 state
 = 2.134.0
 * Removed waypoint WP20.3 between points 20 and 21
 = 2.133.0


### PR DESCRIPTION
## Summary
- revert GN Mapbox plugin to version 2.134.0 codebase
- bump plugin version to 2.138.0

## Testing
- `eslint js`
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2ff0ab888327a49c5a77e79d04f7