### PR TITLE
[Fix] revert plugin to 2.134.0 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,10 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
+### 2.140.0
+- Reverted plugin to version 2.134.0 state
 ### 2.138.0
 - Reverted plugin to version 2.134.0 state
-
-### 2.139.0
-- Marker interactions updated for mobile and desktop
-- Navigation panel layout improvements
 
 ### 2.134.0
 - Removed waypoint WP20.3 between points 20 and 21

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -115,11 +115,9 @@
 /* Navigation panel override for mobile */
 @media (max-width: 767px) {
   #gn-nav-panel {
-    width: 100% !important;
-    left: 0 !important;
-    right: 0 !important;
-    top: auto !important;
-    bottom: 0;
+    width: 110px !important;
+    left: 5vw !important;
+    top: 10vh !important;
   }
   #gn-debug-panel {
     width: 300px !important;
@@ -242,68 +240,6 @@
   z-index: 9998;
   width: 30px;
   padding: 4px;
-}
-
-/* === Marker Styles === */
-.gn-marker {
-  width: 24px;
-  height: 24px;
-  background-color: #db8718;
-  border-radius: 50%;
-  border: 2px solid #fff;
-  box-shadow: 0 0 2px rgba(0, 0, 0, 0.3);
-}
-
-@media (min-width: 768px) {
-  .gn-marker:hover {
-    background-color: #002d44;
-  }
-}
-
-@media (max-width: 767px) {
-  .gn-marker.active {
-    background-color: #002d44;
-  }
-}
-
-/* === Navigation Panel === */
-#gn-nav-panel {
-  width: 50%;
-  border-radius: 8px;
-}
-
-#gn-nav-panel .gn-nav-header {
-  cursor: move;
-  background: #002d44;
-  color: #fff;
-  padding: 4px;
-  font-size: 13px;
-}
-
-#gn-nav-panel .gn-close-btn {
-  float: right;
-  background: none;
-  border: none;
-  color: #fff;
-  font-size: 16px;
-  cursor: pointer;
-}
-
-#gn-nav-panel .gn-nav-body {
-  padding: 6px;
-  background: #fff;
-}
-
-#gn-nav-panel .gn-row1,
-#gn-nav-panel .gn-row2 {
-  display: flex;
-  gap: 4px;
-  margin-bottom: 4px;
-}
-
-#gn-nav-panel .gn-row1 > *,
-#gn-nav-panel .gn-row2 > * {
-  flex: 1;
 }
 
 /* === Custom Markers === */

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.139.0
+Version: 2.140.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.139.0
+Stable tag: 2.140.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.140.0
+* Reverted plugin to version 2.134.0 state
 = 2.138.0
 * Reverted plugin to version 2.134.0 state
 = 2.134.0


### PR DESCRIPTION
## Summary
- revert UI and marker behavior changes
- bump plugin version to 2.140.0
- update changelog entries

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*
- `phpcs --standard=PSR12 gn-mapbox-plugin.php` *(fails: command not found)*
- `eslint js/mapbox-init.js` *(fails: missing config)*

------
https://chatgpt.com/codex/tasks/task_e_686c3c4543908327a311a244cbf42e17