### PR TITLE
[Feature] update navigation UI and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
 
-### 2.141.0
-- Adjust colors for routes and markers
-### 2.140.0
-- Reverted plugin to version 2.134.0 state
-### 2.138.0
-- Reverted plugin to version 2.134.0 state
+### 2.135.0
+- UI updates for navigation panel and markers
 
 ### 2.134.0
 - Removed waypoint WP20.3 between points 20 and 21

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -112,12 +112,20 @@
   display: none;
 }
 
+#gn-nav-panel {
+  width: 50%;
+  max-width: 320px;
+  border-radius: 8px;
+}
+
 /* Navigation panel override for mobile */
 @media (max-width: 767px) {
   #gn-nav-panel {
-    width: 180px !important;
-    left: 5vw !important;
+    width: 100% !important;
+    left: 0 !important;
+    right: 0 !important;
     top: 10vh !important;
+    margin: 0 auto !important;
   }
   #gn-debug-panel {
     width: 300px !important;
@@ -141,9 +149,29 @@
   background-color: #005f91;
 }
 
+.gn-nav-header {
+  cursor: move;
+  background: #002d44;
+  color: #fff;
+  padding: 4px;
+  font-size: 13px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.gn-nav-content {
+  padding: 6px;
+  background: #fff;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+}
+
+.gn-nav-content .gn-nav-btn {
+  grid-column: span 1;
+}
+
 .gn-nav-select {
-  display: block;
-  margin-bottom: 4px;
   width: 100%;
   padding: 4px 6px;
   font-size: 13px;
@@ -244,6 +272,15 @@
 
 /* === Custom Markers === */
 /* Default Mapbox marker icons are used. */
+.gn-location-marker {
+  transition: transform 0.1s;
+  cursor: pointer;
+  outline: none;
+}
+.gn-location-marker.selected {
+  background-color: #002d44 !important;
+  transform: scale(1.1);
+}
 
 /* === Description Toggle === */
 .gn-desc-label {

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.141.0
+Version: 2.135.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -822,7 +822,7 @@ function gn_mapbox_drouseia_shortcode() {
           type: 'fill',
           source: 'drouseia-area',
           paint: {
-            'fill-color': '#DB8718',
+            'fill-color': '#ff0000',
             'fill-opacity': 0.1
           }
         });
@@ -831,7 +831,7 @@ function gn_mapbox_drouseia_shortcode() {
           type: 'line',
           source: 'drouseia-area',
           paint: {
-            'line-color': '#DB8718',
+            'line-color': '#ff0000',
             'line-width': 3
           }
         });
@@ -898,7 +898,7 @@ function gn_mapbox_drouseia_100_shortcode() {
           type: 'fill',
           source: 'drouseia-area',
           paint: {
-            'fill-color': '#DB8718',
+            'fill-color': '#ff0000',
             'fill-opacity': 0.1
           }
         });
@@ -907,7 +907,7 @@ function gn_mapbox_drouseia_100_shortcode() {
           type: 'line',
           source: 'drouseia-area',
           paint: {
-            'line-color': '#DB8718',
+            'line-color': '#ff0000',
             'line-width': 3
           }
         });

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -125,41 +125,43 @@ document.addEventListener("DOMContentLoaded", function () {
     const navPanel = document.createElement("div");
     navPanel.id = "gn-nav-panel";
     navPanel.innerHTML = `
-      <div style="cursor: move; background: #002d44; color: #fff; padding: 4px; font-size:13px; border-top-left-radius:6px;border-top-right-radius:6px;">
+      <div class="gn-nav-header">
         ☰ Navigation
-        <button id="gn-close-nav" style="float:right;background:none;border:none;color:#fff;font-size:16px;cursor:pointer">×</button>
+        <button id="gn-close-nav">×</button>
       </div>
-      <div id="gn-nav-controls" style="padding: 6px; background: white; display:grid;grid-template-columns:repeat(3,1fr);gap:4px;border-bottom-left-radius:6px;border-bottom-right-radius:6px;">
-          <select id="gn-route-select" class="gn-nav-select">
-            <option value="">Select Route</option>
-            <option value="default">Nature Path</option>
-            <option value="paphos">Drousia → Paphos</option>
-            <option value="polis">Drousia → Polis</option>
-            <option value="airport">Paphos → Airport</option>
-          </select>
-          <select id="gn-mode-select" class="gn-nav-select">
-            <option value="driving" title="Driving">🚗</option>
-            <option value="walking" title="Walking">🚶</option>
-            <option value="cycling" title="Cycling">🚲</option>
-          </select>
-          <select id="gn-language-select" class="gn-nav-select">
-            <option value="en-US" title="English">🇬🇧</option>
-            <option value="el-GR" title="Ελληνικά">🇬🇷</option>
-          </select>
-          <div id="gn-distance-panel" style="font-size:12px;margin-bottom:4px;grid-column:span 3;"></div>
-          <button class="gn-nav-btn" id="gn-start-nav" title="Start Navigation">▶</button>
+      <div class="gn-nav-content">
+        <select id="gn-route-select" class="gn-nav-select">
+          <option value="">Select Route</option>
+          <option value="default">Nature Path</option>
+          <option value="paphos">Drousia → Paphos</option>
+          <option value="polis">Drousia → Polis</option>
+          <option value="airport">Paphos → Airport</option>
+        </select>
+        <select id="gn-mode-select" class="gn-nav-select">
+          <option value="driving" title="Driving">🚗 Driving</option>
+          <option value="walking" title="Walking">🚶 Walking</option>
+          <option value="cycling" title="Cycling">🚲 Cycling</option>
+        </select>
+        <select id="gn-language-select" class="gn-nav-select">
+          <option value="en-US" title="English">English</option>
+          <option value="el-GR" title="Ελληνικά">Ελληνικά</option>
+        </select>
+        <button class="gn-nav-btn" id="gn-start-nav">▶ Start Navigation</button>
+        <button class="gn-nav-btn" id="gn-voice-toggle">Mute Directions</button>
       </div>
+      <div id="gn-distance-panel" style="font-size:12px;margin-top:4px;"></div>
     `;
     navPanel.style.cssText = `
       position: fixed;
       top: 100px;
       left: 10px;
-      width: 180px;
+      width: 50%;
+      max-width: 320px;
       z-index: 9998;
       border: 1px solid #ccc;
+      border-radius: 8px;
       box-shadow: 0 2px 5px rgba(0,0,0,0.3);
       background: #fff;
-      border-radius: 6px;
       font-family: sans-serif;
     `;
     document.body.appendChild(navPanel);
@@ -225,26 +227,27 @@ document.addEventListener("DOMContentLoaded", function () {
       openBtn.style.display = 'block';
     };
 
-    document.getElementById("gn-start-nav").onclick = startNavigation;
+    const startBtn = document.getElementById("gn-start-nav");
+    startBtn.onclick = () => {
+      if (watchId) stopNavigation();
+      else startNavigation();
+    };
     addVoiceToggleButton();
   }
 
   function addVoiceToggleButton() {
-    const btn = document.createElement("button");
-    btn.id = "gn-voice-toggle";
-    btn.title = "Toggle Voice";
-    btn.textContent = localStorage.getItem("gn_voice_muted") === "true" ? "🔇" : "🔊";
-    btn.className = "gn-nav-btn";
-    btn.style.marginTop = "0";
-
-    btn.onclick = () => {
-      const isMuted = localStorage.getItem("gn_voice_muted") === "true";
-      localStorage.setItem("gn_voice_muted", !isMuted);
-      btn.textContent = !isMuted ? "🔇" : "🔊";
+    const btn = document.getElementById('gn-voice-toggle');
+    if (!btn) return;
+    const update = () => {
+      const muted = localStorage.getItem('gn_voice_muted') === 'true';
+      btn.textContent = muted ? '🔊 Unmute Directions' : '🔇 Mute Directions';
     };
-
-    const panel = document.getElementById("gn-nav-controls");
-    if (panel) panel.appendChild(btn);
+    btn.addEventListener('click', () => {
+      const muted = localStorage.getItem('gn_voice_muted') === 'true';
+      localStorage.setItem('gn_voice_muted', !muted);
+      update();
+    });
+    update();
   }
 
   function setupLightbox() {
@@ -305,6 +308,12 @@ document.addEventListener("DOMContentLoaded", function () {
     trail = [];
   }
 
+  function stopNavigation() {
+    clearMap();
+    const btn = document.getElementById('gn-start-nav');
+    if (btn) btn.textContent = '▶ Start Navigation';
+  }
+
   async function showDefaultRoute() {
     clearMap();
     log('Showing default route');
@@ -341,19 +350,19 @@ document.addEventListener("DOMContentLoaded", function () {
           .setLngLat([loc.lng, loc.lat])
           .addTo(map);
         const el = marker.getElement();
-        el.addEventListener('click', () => {
-          markers.forEach(m => {
-            const e = m.getElement();
-            if (e) e.style.backgroundColor = '#1198B3';
-          });
-          el.style.backgroundColor = '#002D44';
-        });
-        el.addEventListener('mouseenter', () => {
+        el.classList.add('gn-location-marker');
+        const showPopup = () => {
           popups.forEach(p => p.remove());
           popups = [];
           popup.setLngLat([loc.lng, loc.lat]).addTo(map);
           popups.push(popup);
-        });
+          document
+            .querySelectorAll('.gn-location-marker.selected')
+            .forEach(m => m.classList.remove('selected'));
+          el.classList.add('selected');
+        };
+        el.addEventListener('mouseenter', showPopup);
+        el.addEventListener('click', showPopup);
         markers.push(marker);
       }
     });
@@ -729,8 +738,9 @@ document.addEventListener("DOMContentLoaded", function () {
           type: "line",
           source: "nav-route",
           paint: {
-            "line-color": "#ECF1F8",
-            "line-width": 6
+            "line-color": "#DB8718",
+            "line-width": 6,
+            "line-dasharray": [2, 2],
           },
         });
       }
@@ -800,14 +810,20 @@ document.addEventListener("DOMContentLoaded", function () {
     }, err => {
       log("Geolocation error:", err.message);
     });
+    const btn = document.getElementById('gn-start-nav');
+    if (btn) btn.textContent = '■ Stop Navigation';
   }
 
   setupDebugPanel();
   setupNavPanel();
   setupLightbox();
   function updateTracker(coord) {
-    const icon = navigationMode === 'cycling' ? 'bicycle-15'
-      : navigationMode === 'walking' ? 'pedestrian-15' : 'car-15';
+    const icon =
+      navigationMode === 'driving'
+        ? 'car-15'
+        : navigationMode === 'cycling'
+          ? 'bicycle-15'
+          : 'pedestrian-15';
     if (!map.getSource('route-tracker')) {
       map.addSource('route-tracker', {
         type: 'geojson',
@@ -817,7 +833,7 @@ document.addEventListener("DOMContentLoaded", function () {
         id: 'route-tracker',
         type: 'symbol',
         source: 'route-tracker',
-        layout: { 'icon-image': icon, 'icon-size': 1 }
+        layout: { 'icon-image': icon, 'icon-size': 1 },
       });
     } else {
       map.getSource('route-tracker').setData({ type: 'Feature', geometry: { type: 'Point', coordinates: coord } });

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.141.0
+Stable tag: 2.135.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,12 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
-= 2.141.0
-* Adjust colors for routes and markers
-= 2.140.0
-* Reverted plugin to version 2.134.0 state
-= 2.138.0
-* Reverted plugin to version 2.134.0 state
+= 2.135.0
+* UI updates for navigation panel and markers
 = 2.134.0
 * Removed waypoint WP20.3 between points 20 and 21
 = 2.133.0


### PR DESCRIPTION
## Summary
- revert to plugin version 2.134.0 baseline
- restyle navigation panel and markers
- switch tracker icon based on navigation mode
- open marker popups on click
- bump plugin to 2.135.0

## Testing
- `npx eslint js/mapbox-init.js` *(fails: ESLint config missing)*
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c41212ba08327bff4dc45a5b49701