### PR TITLE
[Fix] revert to v2.134.0 and bump plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
-
-### 2.135.0
-- UI updates for navigation panel and markers
+### 2.142.0
+- Reverted plugin to version 2.134.0 state
 
 ### 2.134.0
 - Removed waypoint WP20.3 between points 20 and 21

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -112,20 +112,12 @@
   display: none;
 }
 
-#gn-nav-panel {
-  width: 50%;
-  max-width: 320px;
-  border-radius: 8px;
-}
-
 /* Navigation panel override for mobile */
 @media (max-width: 767px) {
   #gn-nav-panel {
-    width: 100% !important;
-    left: 0 !important;
-    right: 0 !important;
+    width: 110px !important;
+    left: 5vw !important;
     top: 10vh !important;
-    margin: 0 auto !important;
   }
   #gn-debug-panel {
     width: 300px !important;
@@ -149,29 +141,9 @@
   background-color: #005f91;
 }
 
-.gn-nav-header {
-  cursor: move;
-  background: #002d44;
-  color: #fff;
-  padding: 4px;
-  font-size: 13px;
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
-}
-
-.gn-nav-content {
-  padding: 6px;
-  background: #fff;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 4px;
-}
-
-.gn-nav-content .gn-nav-btn {
-  grid-column: span 1;
-}
-
 .gn-nav-select {
+  display: block;
+  margin-bottom: 4px;
   width: 100%;
   padding: 4px 6px;
   font-size: 13px;
@@ -272,15 +244,6 @@
 
 /* === Custom Markers === */
 /* Default Mapbox marker icons are used. */
-.gn-location-marker {
-  transition: transform 0.1s;
-  cursor: pointer;
-  outline: none;
-}
-.gn-location-marker.selected {
-  background-color: #002d44 !important;
-  transform: scale(1.1);
-}
 
 /* === Description Toggle === */
 .gn-desc-label {

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.135.0
+Version: 2.142.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -125,41 +125,38 @@ document.addEventListener("DOMContentLoaded", function () {
     const navPanel = document.createElement("div");
     navPanel.id = "gn-nav-panel";
     navPanel.innerHTML = `
-      <div class="gn-nav-header">
+      <div style="cursor: move; background: #333; color: #fff; padding: 4px; font-size:13px;">
         ☰ Navigation
-        <button id="gn-close-nav">×</button>
+        <button id="gn-close-nav" style="float:right;background:none;border:none;color:#fff;font-size:16px;cursor:pointer">×</button>
       </div>
-      <div class="gn-nav-content">
-        <select id="gn-route-select" class="gn-nav-select">
-          <option value="">Select Route</option>
-          <option value="default">Nature Path</option>
-          <option value="paphos">Drousia → Paphos</option>
-          <option value="polis">Drousia → Polis</option>
-          <option value="airport">Paphos → Airport</option>
-        </select>
-        <select id="gn-mode-select" class="gn-nav-select">
-          <option value="driving" title="Driving">🚗 Driving</option>
-          <option value="walking" title="Walking">🚶 Walking</option>
-          <option value="cycling" title="Cycling">🚲 Cycling</option>
-        </select>
-        <select id="gn-language-select" class="gn-nav-select">
-          <option value="en-US" title="English">English</option>
-          <option value="el-GR" title="Ελληνικά">Ελληνικά</option>
-        </select>
-        <button class="gn-nav-btn" id="gn-start-nav">▶ Start Navigation</button>
-        <button class="gn-nav-btn" id="gn-voice-toggle">Mute Directions</button>
+      <div style="padding: 6px; background: white;">
+          <select id="gn-route-select" class="gn-nav-select">
+            <option value="">Select Route</option>
+            <option value="default">Nature Path</option>
+            <option value="paphos">Drousia → Paphos</option>
+            <option value="polis">Drousia → Polis</option>
+            <option value="airport">Paphos → Airport</option>
+          </select>
+          <select id="gn-mode-select" class="gn-nav-select">
+            <option value="driving" title="Driving">🚗</option>
+            <option value="walking" title="Walking">🚶</option>
+            <option value="cycling" title="Cycling">🚲</option>
+          </select>
+          <select id="gn-language-select" class="gn-nav-select">
+            <option value="en-US" title="English">🇬🇧</option>
+            <option value="el-GR" title="Ελληνικά">🇬🇷</option>
+          </select>
+          <div id="gn-distance-panel" style="font-size:12px;margin-bottom:4px;"></div>
+          <button class="gn-nav-btn" id="gn-start-nav" title="Start Navigation">▶</button>
       </div>
-      <div id="gn-distance-panel" style="font-size:12px;margin-top:4px;"></div>
     `;
     navPanel.style.cssText = `
       position: fixed;
       top: 100px;
       left: 10px;
-      width: 50%;
-      max-width: 320px;
+      width: 110px;
       z-index: 9998;
       border: 1px solid #ccc;
-      border-radius: 8px;
       box-shadow: 0 2px 5px rgba(0,0,0,0.3);
       background: #fff;
       font-family: sans-serif;
@@ -227,27 +224,26 @@ document.addEventListener("DOMContentLoaded", function () {
       openBtn.style.display = 'block';
     };
 
-    const startBtn = document.getElementById("gn-start-nav");
-    startBtn.onclick = () => {
-      if (watchId) stopNavigation();
-      else startNavigation();
-    };
+    document.getElementById("gn-start-nav").onclick = startNavigation;
     addVoiceToggleButton();
   }
 
   function addVoiceToggleButton() {
-    const btn = document.getElementById('gn-voice-toggle');
-    if (!btn) return;
-    const update = () => {
-      const muted = localStorage.getItem('gn_voice_muted') === 'true';
-      btn.textContent = muted ? '🔊 Unmute Directions' : '🔇 Mute Directions';
+    const btn = document.createElement("button");
+    btn.id = "gn-voice-toggle";
+    btn.title = "Toggle Voice";
+    btn.textContent = localStorage.getItem("gn_voice_muted") === "true" ? "🔇" : "🔊";
+    btn.className = "gn-nav-btn";
+    btn.style.marginTop = "10px";
+
+    btn.onclick = () => {
+      const isMuted = localStorage.getItem("gn_voice_muted") === "true";
+      localStorage.setItem("gn_voice_muted", !isMuted);
+      btn.textContent = !isMuted ? "🔇" : "🔊";
     };
-    btn.addEventListener('click', () => {
-      const muted = localStorage.getItem('gn_voice_muted') === 'true';
-      localStorage.setItem('gn_voice_muted', !muted);
-      update();
-    });
-    update();
+
+    const panel = document.getElementById("gn-nav-panel");
+    panel.querySelector("div:last-child").appendChild(btn);
   }
 
   function setupLightbox() {
@@ -308,12 +304,6 @@ document.addEventListener("DOMContentLoaded", function () {
     trail = [];
   }
 
-  function stopNavigation() {
-    clearMap();
-    const btn = document.getElementById('gn-start-nav');
-    if (btn) btn.textContent = '▶ Start Navigation';
-  }
-
   async function showDefaultRoute() {
     clearMap();
     log('Showing default route');
@@ -346,23 +336,16 @@ document.addEventListener("DOMContentLoaded", function () {
         </div>`;
       if (!loc.waypoint) {
         const popup = new mapboxgl.Popup({ offset: 25 }).setHTML(popupHTML);
-        const marker = new mapboxgl.Marker({ color: '#1198B3' })
+        const marker = new mapboxgl.Marker()
           .setLngLat([loc.lng, loc.lat])
           .addTo(map);
         const el = marker.getElement();
-        el.classList.add('gn-location-marker');
-        const showPopup = () => {
+        el.addEventListener('mouseenter', () => {
           popups.forEach(p => p.remove());
           popups = [];
           popup.setLngLat([loc.lng, loc.lat]).addTo(map);
           popups.push(popup);
-          document
-            .querySelectorAll('.gn-location-marker.selected')
-            .forEach(m => m.classList.remove('selected'));
-          el.classList.add('selected');
-        };
-        el.addEventListener('mouseenter', showPopup);
-        el.addEventListener('click', showPopup);
+        });
         markers.push(marker);
       }
     });
@@ -391,7 +374,7 @@ document.addEventListener("DOMContentLoaded", function () {
           type: 'line',
           source: 'route',
           layout: { 'line-join': 'round', 'line-cap': 'round' },
-          paint: { 'line-color': '#DB8718', 'line-width': 4 }
+          paint: { 'line-color': '#ff0000', 'line-width': 4 }
         });
         log('Route line drawn with', res.coordinates.length, 'points');
       } else {
@@ -436,7 +419,7 @@ document.addEventListener("DOMContentLoaded", function () {
         type: 'line',
         source: 'route',
         layout: { 'line-join': 'round', 'line-cap': 'round' },
-        paint: { 'line-color': '#DB8718', 'line-width': 4 }
+        paint: { 'line-color': '#ff0000', 'line-width': 4 }
       });
       log('Route line drawn with', res.coordinates.length, 'points');
     } else {
@@ -738,7 +721,7 @@ document.addEventListener("DOMContentLoaded", function () {
           type: "line",
           source: "nav-route",
           paint: {
-            "line-color": "#DB8718",
+            "line-color": "#007cbf",
             "line-width": 6,
             "line-dasharray": [2, 2],
           },
@@ -810,34 +793,29 @@ document.addEventListener("DOMContentLoaded", function () {
     }, err => {
       log("Geolocation error:", err.message);
     });
-    const btn = document.getElementById('gn-start-nav');
-    if (btn) btn.textContent = '■ Stop Navigation';
   }
 
   setupDebugPanel();
   setupNavPanel();
   setupLightbox();
   function updateTracker(coord) {
-    const icon =
-      navigationMode === 'driving'
-        ? 'car-15'
-        : navigationMode === 'cycling'
-          ? 'bicycle-15'
-          : 'pedestrian-15';
     if (!map.getSource('route-tracker')) {
       map.addSource('route-tracker', {
         type: 'geojson',
         data: { type: 'Feature', geometry: { type: 'Point', coordinates: coord } }
       });
-      map.addLayer({
-        id: 'route-tracker',
-        type: 'symbol',
-        source: 'route-tracker',
-        layout: { 'icon-image': icon, 'icon-size': 1 },
+      map.loadImage('https://cdn-icons-png.flaticon.com/512/535/535239.png', (error, image) => {
+        if (error) throw error;
+        if (!map.hasImage('hiker-icon')) map.addImage('hiker-icon', image);
+        map.addLayer({
+          id: 'route-tracker',
+          type: 'symbol',
+          source: 'route-tracker',
+          layout: { 'icon-image': 'hiker-icon', 'icon-size': 0.1, 'icon-rotate': 0 }
+        });
       });
     } else {
       map.getSource('route-tracker').setData({ type: 'Feature', geometry: { type: 'Point', coordinates: coord } });
-      map.setLayoutProperty('route-tracker', 'icon-image', icon);
     }
 
     if (!map.getSource('trail-line')) {
@@ -849,7 +827,7 @@ document.addEventListener("DOMContentLoaded", function () {
         id: 'trail-line',
         type: 'line',
         source: 'trail-line',
-        paint: { 'line-color': '#DB8718', 'line-width': 3, 'line-opacity': 0.7 }
+        paint: { 'line-color': '#ff0000', 'line-width': 3, 'line-opacity': 0.7 }
       });
     }
     trail.push(coord);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.135.0
+Stable tag: 2.142.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,8 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
-= 2.135.0
-* UI updates for navigation panel and markers
+= 2.142.0
+* Reverted plugin to version 2.134.0 state
+
 = 2.134.0
 * Removed waypoint WP20.3 between points 20 and 21
 = 2.133.0


### PR DESCRIPTION
## Summary
- roll back plugin files to the 2.134.0 baseline
- set plugin version to 2.142.0
- document the revert in README and changelog

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: `php` not found)*
- `npx eslint js/mapbox-init.js` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d4689be588327b91f1259b23d82b2