### PR TITLE
[Fix] revert to v2.145.0 code and bump plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
-### 2.147.0
-- Improved language switching and navigation fixes
+### 2.148.0
+- Reverted to v2.145.0 code base and bumped version
 ### 2.145.0
 - Navigation UI improvements and bug fixes
 

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -8,8 +8,8 @@
 
 /* Popup layout */
 #gn-mapbox-map .mapboxgl-popup-content {
-  width: 33vw !important;
-  max-width: 33vw !important;
+  width: 50vw !important;
+  max-width: 50vw !important;
   padding: 0 !important;
   box-sizing: border-box !important;
   background: #fff !important;
@@ -122,11 +122,10 @@
 /* Navigation panel override for mobile */
 @media (max-width: 767px) {
   #gn-nav-panel {
-    width: calc(100% - 60px) !important;
-    left: 60px !important;
+    width: 90% !important;
+    left: 50% !important;
     top: 10px !important;
-    right: auto !important;
-    transform: none !important;
+    transform: translateX(-50%) !important;
   }
   #gn-debug-panel {
     width: 300px !important;
@@ -257,13 +256,6 @@
   z-index: 9998;
   width: 30px;
   padding: 4px;
-}
-
-@media (max-width: 767px) {
-  #gn-open-nav {
-    left: 60px !important;
-    right: auto !important;
-  }
 }
 
 /* === Custom Markers === */

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.147.0
+Version: 2.148.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.147.0
+Stable tag: 2.148.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- revert plugin files to v2.145.0 state
- bump plugin version to 2.148.0

## Testing
- `php -l gn-mapbox-plugin.php` *(fails: command not found)*
- `npx eslint js/mapbox-init.js` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d7201e6148327b8657a36b3ea1807