### PR TITLE
[Feature] show covered route

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.149.0
+- Covered segments of the route now display in green during navigation
+- Bumped plugin version
 ### 2.148.0
 - Reverted to v2.145.0 code base and bumped version
 ### 2.145.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.148.0
+Version: 2.149.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -881,7 +881,12 @@ document.addEventListener("DOMContentLoaded", function () {
         id: 'trail-line',
         type: 'line',
         source: 'trail-line',
-        paint: { 'line-color': '#002D44', 'line-width': 3, 'line-opacity': 0.7 }
+        paint: {
+          // show covered portion of the route in green
+          'line-color': '#66cc33',
+          'line-width': 3,
+          'line-opacity': 0.7
+        }
       });
     }
     trail.push(coord);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.148.0
+Stable tag: 2.149.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- highlight covered route sections in navigation mode
- bump plugin version

## Testing
- `php -l gn-mapbox-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_68766f06c7008327ace7464790cee88b