### PR TITLE
[Fix] ensure voice toggle resumes speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.149.0
+- Voice toggle immediately resumes or stops current navigation speech
 ### 2.148.0
 - Reverted to v2.145.0 code base and bumped version
 ### 2.145.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.148.0
+Version: 2.149.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -245,6 +245,11 @@ document.addEventListener("DOMContentLoaded", function () {
       btn.textContent = !wasMuted ? "🔇 Mute Directions" : "🔊 Unmute Directions";
       if (!wasMuted && window.speechSynthesis) {
         window.speechSynthesis.cancel();
+      } else if (wasMuted && isNavigating && window.gnNavState) {
+        const { steps, stepIndex, speakInstruction } = window.gnNavState;
+        if (steps && steps[stepIndex]) {
+          speakInstruction(steps[stepIndex]);
+        }
       }
     };
 
@@ -316,6 +321,7 @@ document.addEventListener("DOMContentLoaded", function () {
       watchId = null;
     }
     trail = [];
+    window.gnNavState = null;
     isNavigating = false;
     const btn = document.getElementById('gn-nav-toggle');
     if (btn) btn.textContent = '▶ Start Navigation';
@@ -806,6 +812,7 @@ document.addEventListener("DOMContentLoaded", function () {
         msg.volume = 1.0;
         if (!isVoiceMuted()) window.speechSynthesis.speak(msg);
       };
+      window.gnNavState = { steps, stepIndex, speakInstruction };
       if (steps.length) speakInstruction(steps[0]);
 
       const calcRemaining = (cur) => {
@@ -829,6 +836,9 @@ document.addEventListener("DOMContentLoaded", function () {
           const target = steps[stepIndex].maneuver.location;
           if (haversineDistance(cur, target) < 20) {
             stepIndex++;
+            if (window.gnNavState) {
+              window.gnNavState.stepIndex = stepIndex;
+            }
             if (stepIndex < steps.length) speakInstruction(steps[stepIndex]);
           }
         }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.148.0
+Stable tag: 2.149.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- allow unmute button to immediately speak the current navigation step
- track navigation state globally
- reset navigation state when clearing map
- bump plugin version to 2.149.0

## Testing
- `php -l gn-mapbox-plugin.php`
- `npx eslint js --ext .js` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68766f77368483279ca9a1a5e7ff1e18