### PR TITLE
[Fix] Correct navigation for driving routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.150.0
+- Fixed Directions API request when starting navigation on driving routes
+- Bumped plugin version
 ### 2.149.0
 - All routes now use the Mapbox Directions API for navigation
-
-
 - Covered segments of the route now display in green during navigation
 - Bumped plugin version
 ### 2.148.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.149.0
+Version: 2.150.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -729,9 +729,15 @@ document.addEventListener("DOMContentLoaded", function () {
       const destination = coords[coords.length - 1];
       const ordered = [userLngLat, ...waypoints, destination];
       const stopIndexes = [0];
-      gnMapData.locations.forEach((loc, i) => {
-        if (!loc.waypoint) stopIndexes.push(i + 1);
-      });
+      if (currentRoute === 'default') {
+        gnMapData.locations.forEach((loc, i) => {
+          if (!loc.waypoint) stopIndexes.push(i + 1);
+        });
+      } else {
+        for (let i = 1; i < ordered.length; i++) {
+          stopIndexes.push(i);
+        }
+      }
       const bearings = computeBearings(ordered);
       const {
         coordinates: routeCoords,

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.149.0
+Stable tag: 2.150.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.150.0 =
+* Fixed Directions API usage when starting navigation on driving routes
+* Bumped version
 = 2.73.1 =
 * Change some route coordinates
 


### PR DESCRIPTION
## Summary
- handle driving routes when building waypoint list for navigation
- bump plugin version to 2.150.0 and document changes

## Testing
- `php -l gn-mapbox-plugin.php`
- `eslint js/*.js` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_687677214f888327bf8530d7ed8c0d87