### PR TITLE
[Feature] stats panel elevation and version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.151.0
+- Stats panel shows distance, time and elevation for selected routes
+- Bumped plugin version
 ### 2.150.0
 - Fixed Directions API request when starting navigation on driving routes
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.150.0
+Version: 2.151.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -400,6 +400,15 @@ document.addEventListener("DOMContentLoaded", function () {
           layout: { 'line-join': 'round', 'line-cap': 'round' },
           paint: { 'line-color': '#1198B3', 'line-width': 4 }
         });
+        const elevationGain = await getElevationGain(res.coordinates);
+        const panel = document.getElementById('gn-distance-panel');
+        if (panel) {
+          const km = (res.distance / 1000).toFixed(2);
+          const mins = Math.ceil(res.duration / 60);
+          panel.innerHTML = `Distance: ${km} km<br>Time: ${mins} min<br>Elevation: ${Math.round(
+            elevationGain
+          )} m`;
+        }
         log('Route line drawn with', res.coordinates.length, 'points');
       } else {
         log('No coordinates returned for default route');
@@ -445,6 +454,15 @@ document.addEventListener("DOMContentLoaded", function () {
         layout: { 'line-join': 'round', 'line-cap': 'round' },
         paint: { 'line-color': '#1198B3', 'line-width': 4 }
       });
+      const elevationGain = await getElevationGain(res.coordinates);
+      const panel = document.getElementById('gn-distance-panel');
+      if (panel) {
+        const km = (res.distance / 1000).toFixed(2);
+        const mins = Math.ceil(res.duration / 60);
+        panel.innerHTML = `Distance: ${km} km<br>Time: ${mins} min<br>Elevation: ${Math.round(
+          elevationGain
+        )} m`;
+      }
       log('Route line drawn with', res.coordinates.length, 'points');
     } else {
       log('No coordinates returned for route');

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.150.0
+Stable tag: 2.151.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.151.0 =
+* Stats panel shows distance, time and elevation for selected routes
+* Bumped version
 = 2.150.0 =
 * Fixed Directions API usage when starting navigation on driving routes
 * Bumped version


### PR DESCRIPTION
## Summary
- show route stats (distance, time, elevation) when selecting routes
- bump plugin version to 2.151.0
- document new version in readme files

## Testing
- `php -l gn-mapbox-plugin.php`
- `eslint js/mapbox-init.js` *(fails: ESLint couldn't find config)*
- `python3 scripts/verify_proximity.py data/locations.json`

------
https://chatgpt.com/codex/tasks/task_e_68789fdd4fb08327a43df1db08f253ae