### PR TITLE
[Fix] keep route line blue during navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.152.0
+- Route line retains blue color during navigation
+- Bumped plugin version
 ### 2.151.0
 - Stats panel shows distance, time and elevation for selected routes
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.151.0
+Version: 2.152.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -792,7 +792,7 @@ document.addEventListener("DOMContentLoaded", function () {
           type: "line",
           source: "nav-route",
           paint: {
-            "line-color": "#002D44",
+            "line-color": "#1198B3",
             "line-width": 8,
           },
         });

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.151.0
+Stable tag: 2.152.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.152.0 =
+* Keep route line blue during navigation
+* Bumped version
 = 2.151.0 =
 * Stats panel shows distance, time and elevation for selected routes
 * Bumped version


### PR DESCRIPTION
## Summary
- keep navigation line consistent with default route color
- bump plugin version to 2.152.0

## Testing
- `php -l gn-mapbox-plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_6878a278202083278d2e0b96c27c544c