### PR TITLE
[Fix] map popup works on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.154.0
+- Fix mobile popups not opening on tap
+- Bumped plugin version
 ### 2.153.0
 - Display location photos in a carousel
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.153.0
+Version: 2.154.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -402,6 +402,7 @@ document.addEventListener("DOMContentLoaded", function () {
         };
         el.addEventListener('mouseenter', showPopup);
         el.addEventListener('click', showPopup);
+        el.addEventListener('touchstart', showPopup);
         markers.push(marker);
       }
     });

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.153.0
+Stable tag: 2.154.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.154.0 =
+* Fix mobile popups not opening on tap
+* Bumped version
 = 2.153.0 =
 * Display location photos in a carousel
 * Bumped version


### PR DESCRIPTION
## Summary
- open marker popup when touching on mobile
- bump plugin version to 2.154.0

## Testing
- `php -l gn-mapbox-plugin.php`
- `eslint js/mapbox-init.js` *(fails: config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878a89e36948327bbb410a47ea082ce