### PR TITLE
[Fix] comment out alerts and bump plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
-### 2.154.0
-- Fix mobile popups not opening on tap
+### 2.155.0
+- Commented out voice alert popups
 - Bumped plugin version
 ### 2.153.0
 - Display location photos in a carousel

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.154.0
+Version: 2.155.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -50,7 +50,7 @@ document.addEventListener("DOMContentLoaded", function () {
         const updatedVoices = window.speechSynthesis.getVoices();
         window.speechSynthesis.removeEventListener("voiceschanged", onVoicesChanged);
         if (!updatedVoices.some(v => v.lang === lang)) {
-          alert(`Voice for ${lang} not found. Please install it from your system's language or speech settings to enable spoken directions.`);
+          // alert(`Voice for ${lang} not found. Please install it from your system's language or speech settings to enable spoken directions.`);
         }
       };
       window.speechSynthesis.addEventListener("voiceschanged", onVoicesChanged);
@@ -59,7 +59,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }
     const hasVoice = voices.some(v => v.lang === lang);
     if (!hasVoice) {
-      alert(`Voice for ${lang} not found. Please install it from your system's language or speech settings to enable spoken directions.`);
+      // alert(`Voice for ${lang} not found. Please install it from your system's language or speech settings to enable spoken directions.`);
     }
     return hasVoice;
   }
@@ -766,7 +766,7 @@ document.addEventListener("DOMContentLoaded", function () {
     navigator.geolocation.getCurrentPosition(async (pos) => {
         const lang = getSelectedLanguage();
         if (!window.speechSynthesis) {
-          alert("Voice guidance is not supported in your browser.");
+          // alert("Voice guidance is not supported in your browser.");
         } else {
           checkVoiceAvailability(lang);
           if (!localStorage.getItem("gn_voice_prompted")) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.154.0
+Stable tag: 2.155.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,8 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
-= 2.154.0 =
-* Fix mobile popups not opening on tap
+= 2.155.0 =
+* Commented out voice alert popups
 * Bumped version
 = 2.153.0 =
 * Display location photos in a carousel


### PR DESCRIPTION
## Summary
- comment out alert dialogs in `mapbox-init.js`
- bump plugin version to 2.155.0
- update changelog

## Testing
- `npx eslint js/mapbox-init.js` *(fails: ESLint couldn't find a config)*
- `php -l gn-mapbox-plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_6878ac0e30d48327b3b10ca3a9aa47d4