### PR TITLE
[Fix] remove voice consent and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.156.0
+- Removed voice consent prompt
+- Bumped plugin version
 ### 2.155.0
 - Commented out voice alert popups
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.155.0
+Version: 2.156.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -769,11 +769,6 @@ document.addEventListener("DOMContentLoaded", function () {
           // alert("Voice guidance is not supported in your browser.");
         } else {
           checkVoiceAvailability(lang);
-          if (!localStorage.getItem("gn_voice_prompted")) {
-            const consent = confirm(`Enable voice directions in ${lang}?`);
-            if (!consent) localStorage.setItem("gn_voice_muted", true);
-            localStorage.setItem("gn_voice_prompted", true);
-          }
         }
       const userLngLat = [pos.coords.longitude, pos.coords.latitude];
       const waypoints = coords.slice(0, -1);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.155.0
+Stable tag: 2.156.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.156.0 =
+* Removed voice consent prompt
+* Bumped version
 = 2.155.0 =
 * Commented out voice alert popups
 * Bumped version


### PR DESCRIPTION
## Summary
- remove browser confirm prompt for voice navigation
- bump plugin version to 2.156.0

## Testing
- `php -l gn-mapbox-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_6878b10ada9083278375636e535bc6dc