### PR TITLE
[Fix] Responsive popup width

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.157.0
+- Use clamp for responsive popup width
+- Bumped plugin version
 ### 2.156.0
 - Removed voice consent prompt
 - Bumped plugin version

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -8,8 +8,8 @@
 
 /* Popup layout */
 #gn-mapbox-map .mapboxgl-popup-content {
-  width: 50vw !important;
-  max-width: 50vw !important;
+  width: clamp(280px, 90vw, 500px) !important;
+  max-width: clamp(280px, 90vw, 500px) !important;
   padding: 0 !important;
   box-sizing: border-box !important;
   background: #fff !important;
@@ -163,8 +163,8 @@
     bottom: 10vh !important;
   }
   #gn-mapbox-map .mapboxgl-popup-content {
-    width: 100vw !important;
-    max-width: 100vw !important;
+    width: clamp(280px, 95vw, 500px) !important;
+    max-width: clamp(280px, 95vw, 500px) !important;
   }
 }
 

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.156.0
+Version: 2.157.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.156.0
+Stable tag: 2.157.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.157.0 =
+* Use clamp for responsive popup width
+* Bump version
 = 2.156.0 =
 * Removed voice consent prompt
 * Bumped version


### PR DESCRIPTION
## Summary
- adjust popup width using `clamp()` for better responsiveness
- update mobile popup style
- bump plugin version

## Testing
- `php -l gn-mapbox-plugin.php`
- `eslint js` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6878b40f3d1c8327bcdcd5fe56f180bc