### PR TITLE
[Fix] recalc stats on mode change

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.158.0
+- Recalculate stats when changing navigation mode
+- Bumped plugin version
 ### 2.157.0
 - Use clamp for responsive popup width
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.157.0
+Version: 2.158.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -414,7 +414,7 @@ document.addEventListener("DOMContentLoaded", function () {
       const bearings = computeBearings(coords);
       const res = await fetchDirections(
         coords,
-        'walking',
+        navigationMode,
         false,
         getSelectedLanguage(),
         stopIndexes,
@@ -531,9 +531,18 @@ document.addEventListener("DOMContentLoaded", function () {
   window.setMode = function (mode) {
     const sel = document.getElementById("gn-mode-select");
     if (sel) sel.value = mode;
+    const prev = navigationMode;
     navigationMode = mode;
     if (map && map.getLayer('route-tracker')) {
       map.setLayoutProperty('route-tracker', 'text-field', getTrackerEmoji());
+    }
+    if (prev !== mode) {
+      if (isNavigating) {
+        stopNavigation();
+        startNavigation();
+      } else {
+        selectRoute(currentRoute);
+      }
     }
     log(
       "Navigation mode icon:",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.157.0
+Stable tag: 2.158.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.158.0 =
+* Recalculate stats when changing navigation mode
+* Bump version
 = 2.157.0 =
 * Use clamp for responsive popup width
 * Bump version


### PR DESCRIPTION
## Summary
- recalc distance/time/elevation when changing dropdown mode
- reload navigation or route when mode changes
- bump version to 2.158.0

## Testing
- `php -l gn-mapbox-plugin.php`
- `npx eslint js` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6878b6793f7c8327b1caa936e05b5727