### PR TITLE
[Feature] mode icon reflects navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.159.0
+- Current position icon matches selected navigation mode
+- Bumped plugin version
 ### 2.158.0
 - Recalculate stats when changing navigation mode
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.158.0
+Version: 2.159.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -12,8 +12,8 @@ document.addEventListener("DOMContentLoaded", function () {
   mapboxgl.accessToken = gnMapData.accessToken;
   const debugEnabled = gnMapData.debug === true;
   let coords = [];
-  // default icon shows driving but we actually request walking directions
-  let navigationMode = "walking";
+  // initial navigation mode matches dropdown selection
+  let navigationMode = "driving";
   let map;
   let languageControl;
   let markers = [];
@@ -184,6 +184,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const modeSel = navPanel.querySelector("#gn-mode-select");
     if (modeSel) {
       modeSel.value = 'driving';
+      navigationMode = modeSel.value;
       modeSel.onchange = () => setMode(modeSel.value);
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.158.0
+Stable tag: 2.159.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.159.0 =
+* Current position icon matches selected navigation mode
+* Bump version
 = 2.158.0 =
 * Recalculate stats when changing navigation mode
 * Bump version


### PR DESCRIPTION
## Summary
- start with driving mode to match dropdown
- sync navigation mode with the dropdown selection
- show current position icon according to selected mode
- bump plugin version to 2.159.0

## Testing
- `php -l gn-mapbox-plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_6878beb0e4bc83278a84213788314d98