### PR TITLE
[Fix] revert navigation icon change

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
-### 2.159.0
-- Current position icon matches selected navigation mode
+### 2.160.0
+- Reverted navigation mode icon change
 - Bumped plugin version
 ### 2.158.0
 - Recalculate stats when changing navigation mode

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.159.0
+Version: 2.160.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -12,8 +12,8 @@ document.addEventListener("DOMContentLoaded", function () {
   mapboxgl.accessToken = gnMapData.accessToken;
   const debugEnabled = gnMapData.debug === true;
   let coords = [];
-  // initial navigation mode matches dropdown selection
-  let navigationMode = "driving";
+  // default icon shows driving but we actually request walking directions
+  let navigationMode = "walking";
   let map;
   let languageControl;
   let markers = [];
@@ -184,7 +184,6 @@ document.addEventListener("DOMContentLoaded", function () {
     const modeSel = navPanel.querySelector("#gn-mode-select");
     if (modeSel) {
       modeSel.value = 'driving';
-      navigationMode = modeSel.value;
       modeSel.onchange = () => setMode(modeSel.value);
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.159.0
+Stable tag: 2.160.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,8 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
-= 2.159.0 =
-* Current position icon matches selected navigation mode
+= 2.160.0 =
+* Reverted navigation mode icon change
 * Bump version
 = 2.158.0 =
 * Recalculate stats when changing navigation mode


### PR DESCRIPTION
## Summary
- revert plugin code to 2.158.0 state
- bump plugin version to 2.160.0

## Testing
- `php -l gn-mapbox-plugin.php`
- `find . -name '*.php' -not -path './plugin-update-checker/*' -print0 | xargs -0 -n1 php -l`
- `npx eslint js/*.js` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6878cb4a66d48327a6c0d82f1ebfe229