### PR TITLE
[Fix] enlarge tracker icon and update trail color

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.161.0
+- Larger navigation tracker icon
+- Trail line color changed to blue
+- Bumped plugin version
 ### 2.160.0
 - Reverted navigation mode icon change
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.160.0
+Version: 2.161.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -925,7 +925,7 @@ document.addEventListener("DOMContentLoaded", function () {
         source: 'route-tracker',
         layout: {
           'text-field': getTrackerEmoji(),
-          'text-size': 24,
+          'text-size': 36,
           'text-allow-overlap': true
         }
       });
@@ -944,8 +944,8 @@ document.addEventListener("DOMContentLoaded", function () {
         type: 'line',
         source: 'trail-line',
         paint: {
-          // show covered portion of the route in green
-          'line-color': '#66cc33',
+          // show covered portion of the route in blue
+          'line-color': '#007CBF',
           'line-width': 3,
           'line-opacity': 0.7
         }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.160.0
+Stable tag: 2.161.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,10 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.161.0 =
+* Larger navigation tracker icon
+* Trail line color changed to blue
+* Bump version
 = 2.160.0 =
 * Reverted navigation mode icon change
 * Bump version


### PR DESCRIPTION
## Summary
- bump plugin version
- enlarge navigation tracker icon
- make trail line blue
- document plugin version

## Testing
- `php -l gn-mapbox-plugin.php`
- `npx eslint js/mapbox-init.js` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_6878ce2f33948327aa9d268203fc51fc