### PR TITLE
[Fix] Make route tracker visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.162.0
+- Thicker tracker line and visible tracker emoji
+- Bumped plugin version
 ### 2.161.0
 - Larger navigation tracker icon
 - Trail line color changed to blue

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.161.0
+Version: 2.162.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -926,7 +926,13 @@ document.addEventListener("DOMContentLoaded", function () {
         layout: {
           'text-field': getTrackerEmoji(),
           'text-size': 36,
-          'text-allow-overlap': true
+          'text-allow-overlap': true,
+          'text-font': ['Noto Sans Regular', 'Arial Unicode MS Regular']
+        },
+        paint: {
+          'text-color': '#ff4500',
+          'text-halo-color': '#ffffff',
+          'text-halo-width': 2
         }
       });
     } else {
@@ -946,7 +952,7 @@ document.addEventListener("DOMContentLoaded", function () {
         paint: {
           // show covered portion of the route in blue
           'line-color': '#007CBF',
-          'line-width': 3,
+          'line-width': 6,
           'line-opacity': 0.7
         }
       });

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.161.0
+Stable tag: 2.162.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.162.0 =
+* Tracker line thicker and tracker emoji visible
+* Bumped plugin version
 = 2.161.0 =
 * Larger navigation tracker icon
 * Trail line color changed to blue


### PR DESCRIPTION
## Summary
- ensure route tracker emoji uses explicit font and color
- thicken navigation trail line
- update version numbers and changelogs

## Testing
- `php -l gn-mapbox-plugin.php`
- `npx eslint js` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6878e6ede1a88327aef2f3d20d976112