### PR TITLE
[Fix] restore map tracker icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.163.0
+- Replace emoji tracker with Mapbox icons
+- Bumped plugin version
 ### 2.162.0
 - Thicker tracker line and visible tracker emoji
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.162.0
+Version: 2.163.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -534,7 +534,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const prev = navigationMode;
     navigationMode = mode;
     if (map && map.getLayer('route-tracker')) {
-      map.setLayoutProperty('route-tracker', 'text-field', getTrackerEmoji());
+      map.setLayoutProperty('route-tracker', 'icon-image', getTrackerIcon());
     }
     if (prev !== mode) {
       if (isNavigating) {
@@ -909,10 +909,10 @@ document.addEventListener("DOMContentLoaded", function () {
   setupNavPanel();
   setupLightbox();
   setupCarousel();
-  function getTrackerEmoji() {
-    if (navigationMode === 'driving') return '🚗';
-    if (navigationMode === 'cycling') return '🚲';
-    return '🚶';
+  function getTrackerIcon() {
+    if (navigationMode === 'driving') return 'car-15';
+    if (navigationMode === 'cycling') return 'bicycle-15';
+    return 'pedestrian-15';
   }
 
   function updateTracker(coord) {
@@ -924,20 +924,14 @@ document.addEventListener("DOMContentLoaded", function () {
         type: 'symbol',
         source: 'route-tracker',
         layout: {
-          'text-field': getTrackerEmoji(),
-          'text-size': 36,
-          'text-allow-overlap': true,
-          'text-font': ['Noto Sans Regular', 'Arial Unicode MS Regular']
-        },
-        paint: {
-          'text-color': '#ff4500',
-          'text-halo-color': '#ffffff',
-          'text-halo-width': 2
+          'icon-image': getTrackerIcon(),
+          'icon-size': 1.5,
+          'icon-allow-overlap': true
         }
       });
     } else {
       map.getSource('route-tracker').setData(data);
-      map.setLayoutProperty('route-tracker', 'text-field', getTrackerEmoji());
+      map.setLayoutProperty('route-tracker', 'icon-image', getTrackerIcon());
     }
 
     if (!map.getSource('trail-line')) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.162.0
+Stable tag: 2.163.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.163.0 =
+* Replace emoji tracker with Mapbox icons
+* Bumped plugin version
 = 2.162.0 =
 * Tracker line thicker and tracker emoji visible
 * Bumped plugin version


### PR DESCRIPTION
## Summary
- revert to using Mapbox icons instead of emoji for navigation tracker
- update plugin version to 2.163.0
- document changes in README and readme.txt

## Testing
- `php -l gn-mapbox-plugin.php`
- `npx eslint js/mapbox-init.js` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_687f1193e5588327a0921b56b3dac7c0