### PR TITLE
[Fix] correct toggle labels and handle navigation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.164.0
+- Fix toggle button labels for voice and navigation
+- Bumped plugin version
 ### 2.163.0
 - Replace emoji tracker with Mapbox icons
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.163.0
+Version: 2.164.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -236,14 +236,19 @@ document.addEventListener("DOMContentLoaded", function () {
     const btn = document.createElement("button");
     btn.id = "gn-voice-toggle";
     btn.title = "Toggle Voice";
-    btn.textContent = localStorage.getItem("gn_voice_muted") === "true" ? "🔇 Mute Directions" : "🔊 Unmute Directions";
+    btn.textContent = localStorage.getItem("gn_voice_muted") === "true" ? "🔊 Unmute Directions" : "🔇 Mute Directions";
     btn.className = "gn-nav-btn";
 
     btn.onclick = () => {
       const wasMuted = localStorage.getItem("gn_voice_muted") === "true";
-      localStorage.setItem("gn_voice_muted", !wasMuted);
-      btn.textContent = !wasMuted ? "🔇 Mute Directions" : "🔊 Unmute Directions";
-      if (!wasMuted && window.speechSynthesis) {
+      const nowMuted = !wasMuted;
+      localStorage.setItem("gn_voice_muted", nowMuted);
+      btn.textContent = nowMuted ? "🔊 Unmute Directions" : "🔇 Mute Directions";
+      if (wasMuted && window.speechSynthesis) {
+        // voice was muted and is now unmuted
+        // nothing to cancel
+      } else if (!wasMuted && window.speechSynthesis) {
+        // voice was playing and is now muted
         window.speechSynthesis.cancel();
       }
     };
@@ -765,6 +770,9 @@ document.addEventListener("DOMContentLoaded", function () {
   async function startNavigation() {
     if (!navigator.geolocation) {
       log("Geolocation not supported.");
+      isNavigating = false;
+      const btn = document.getElementById('gn-nav-toggle');
+      if (btn) btn.textContent = '▶ Start Navigation';
       return;
     }
 
@@ -809,6 +817,8 @@ document.addEventListener("DOMContentLoaded", function () {
       );
       if (!routeCoords.length) {
         log("No route found.");
+        isNavigating = false;
+        if (toggleBtn) toggleBtn.textContent = '▶ Start Navigation';
         return;
       }
 
@@ -902,6 +912,8 @@ document.addEventListener("DOMContentLoaded", function () {
       // store watchId globally if needed to stop later
     }, err => {
       log("Geolocation error:", err.message);
+      isNavigating = false;
+      if (toggleBtn) toggleBtn.textContent = '▶ Start Navigation';
     });
   }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.163.0
+Stable tag: 2.164.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.164.0 =
+* Fix toggle button labels for voice and navigation
+* Bumped plugin version
 = 2.163.0 =
 * Replace emoji tracker with Mapbox icons
 * Bumped plugin version


### PR DESCRIPTION
## Summary
- fix text for mute/unmute toggle
- reset navigation button when geolocation errors occur
- bump plugin version to 2.164.0

## Testing
- `php -l gn-mapbox-plugin.php`
- `eslint js/*.js` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_687f160c55ac8327bc4e51476b55a776