### PR TITLE
[Fix] restore tracker emoji and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.165.0
+- Restore visible tracker emoji for navigation
+- Bumped plugin version
 ### 2.164.0
 - Fix toggle button labels for voice and navigation
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.164.0
+Version: 2.165.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -539,7 +539,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const prev = navigationMode;
     navigationMode = mode;
     if (map && map.getLayer('route-tracker')) {
-      map.setLayoutProperty('route-tracker', 'icon-image', getTrackerIcon());
+      map.setLayoutProperty('route-tracker', 'text-field', getTrackerEmoji());
     }
     if (prev !== mode) {
       if (isNavigating) {
@@ -921,10 +921,10 @@ document.addEventListener("DOMContentLoaded", function () {
   setupNavPanel();
   setupLightbox();
   setupCarousel();
-  function getTrackerIcon() {
-    if (navigationMode === 'driving') return 'car-15';
-    if (navigationMode === 'cycling') return 'bicycle-15';
-    return 'pedestrian-15';
+  function getTrackerEmoji() {
+    if (navigationMode === 'driving') return '🚗';
+    if (navigationMode === 'cycling') return '🚲';
+    return '🚶';
   }
 
   function updateTracker(coord) {
@@ -936,14 +936,20 @@ document.addEventListener("DOMContentLoaded", function () {
         type: 'symbol',
         source: 'route-tracker',
         layout: {
-          'icon-image': getTrackerIcon(),
-          'icon-size': 1.5,
-          'icon-allow-overlap': true
+          'text-field': getTrackerEmoji(),
+          'text-size': 36,
+          'text-allow-overlap': true,
+          'text-font': ['Noto Sans Regular', 'Arial Unicode MS Regular']
+        },
+        paint: {
+          'text-color': '#ff4500',
+          'text-halo-color': '#ffffff',
+          'text-halo-width': 2
         }
       });
     } else {
       map.getSource('route-tracker').setData(data);
-      map.setLayoutProperty('route-tracker', 'icon-image', getTrackerIcon());
+      map.setLayoutProperty('route-tracker', 'text-field', getTrackerEmoji());
     }
 
     if (!map.getSource('trail-line')) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.164.0
+Stable tag: 2.165.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.165.0 =
+* Restore visible tracker emoji for navigation
+* Bumped plugin version
 = 2.164.0 =
 * Fix toggle button labels for voice and navigation
 * Bumped plugin version


### PR DESCRIPTION
## Summary
- restore visible tracker emoji in navigation
- bump plugin version to 2.165.0

## Testing
- `php -l gn-mapbox-plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_6884e8fa4b808327acb38eb3237c9677