### PR TITLE
[Fix] add tracker debug logs and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.167.0
+- Added debug logs for tracker icon visibility
+- Bumped plugin version
 ### 2.166.0
 - Extremely verbose comments added for clarity
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.166.0
+Version: 2.167.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -928,29 +928,54 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   function updateTracker(coord) {
+    // Convert the provided coordinate into a GeoJSON point so Mapbox GL can
+    // easily render it as a layer source. The tracker layer displays a moving
+    // emoji that represents the user's position during navigation.
     const data = { type: 'Feature', geometry: { type: 'Point', coordinates: coord } };
+
+    // Log whenever updateTracker runs so we know the function is executing and
+    // which coordinate it's attempting to render.
+    console.log('[GN DEBUG]', 'updateTracker called with', coord);
+
     if (!map.getSource('route-tracker')) {
+      // When the source doesn't exist we create both the source and the layer.
+      // This only happens once at the beginning of navigation.
+      console.log('[GN DEBUG]', 'Adding route-tracker source and layer');
       map.addSource('route-tracker', { type: 'geojson', data });
       map.addLayer({
         id: 'route-tracker',
         type: 'symbol',
         source: 'route-tracker',
         layout: {
+          // Tracker emoji indicates the mode of travel. It updates whenever the
+          // navigation mode changes (driving, cycling or walking).
           'text-field': getTrackerEmoji(),
           'text-size': 36,
           'text-allow-overlap': true,
           'text-font': ['Noto Sans Regular', 'Arial Unicode MS Regular']
         },
         paint: {
+          // Use a vibrant orange color with a white halo so the emoji stands out
+          // against any map background.
           'text-color': '#ff4500',
           'text-halo-color': '#ffffff',
           'text-halo-width': 2
         }
       });
     } else {
+      // If the layer already exists, simply update the source data and ensure
+      // the current emoji matches the navigation mode.
+      console.log('[GN DEBUG]', 'Updating existing route-tracker layer');
       map.getSource('route-tracker').setData(data);
       map.setLayoutProperty('route-tracker', 'text-field', getTrackerEmoji());
     }
+
+    // After updating, log the icon actually being used so we can verify it
+    // appears on screen. If the layer failed to add, this will output "null".
+    const icon = map.getLayer('route-tracker')
+      ? map.getLayoutProperty('route-tracker', 'text-field')
+      : null;
+    console.log('[GN DEBUG]', 'Current tracker icon:', icon);
 
     if (!map.getSource('trail-line')) {
       map.addSource('trail-line', {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.166.0
+Stable tag: 2.167.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.167.0 =
+* Added debug logs for tracker icon visibility
+* Bumped plugin version
 = 2.166.0 =
 * Extremely verbose comments added for clarity
 * Bumped plugin version


### PR DESCRIPTION
## Summary
- log tracker emoji updates for easier debugging
- bump plugin version to 2.167.0

## Testing
- `php -l gn-mapbox-plugin.php`
- `npx eslint js/mapbox-init.js` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_6884edb6575c832787d7febc1a60087f