### PR TITLE
[Fix] Replace missing font reference

### DIFF
--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -952,7 +952,8 @@ document.addEventListener("DOMContentLoaded", function () {
           'text-field': getTrackerEmoji(),
           'text-size': 36,
           'text-allow-overlap': true,
-          'text-font': ['Noto Sans Regular', 'Arial Unicode MS Regular']
+          // Use widely supported fonts to avoid 404 errors on Mapbox font API
+          'text-font': ['Open Sans Regular', 'Arial Unicode MS Regular']
         },
         paint: {
           // Use a vibrant orange color with a white halo so the emoji stands out


### PR DESCRIPTION
## Summary
- adjust `text-font` to use `Open Sans` instead of `Noto Sans`

## Testing
- `php -l gn-mapbox-plugin.php`
- `eslint js/mapbox-init.js` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6884ef323c888327af4da80b5e7a5c5a