### PR TITLE
[Fix] add tracker layer check and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.169.0
+- Added missing tracker layer check and bumped plugin version
 ### 2.168.0
 - Bumped plugin version
 ### 2.167.0

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.168.0
+Version: 2.169.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -938,31 +938,37 @@ document.addEventListener("DOMContentLoaded", function () {
     console.log('[GN DEBUG]', 'updateTracker called with', coord);
 
     if (!map.getSource('route-tracker')) {
-      // When the source doesn't exist we create both the source and the layer.
-      // This only happens once at the beginning of navigation.
+      // When the source doesn't exist we create it and also add the layer that
+      // displays the moving tracker icon. This ensures the layer gets added only
+      // once during initial navigation start.
       console.log('[GN DEBUG]', 'Adding route-tracker source and layer');
       map.addSource('route-tracker', { type: 'geojson', data });
-      map.addLayer({
-        id: 'route-tracker',
-        type: 'symbol',
-        source: 'route-tracker',
-        layout: {
-          // Tracker emoji indicates the mode of travel. It updates whenever the
-          // navigation mode changes (driving, cycling or walking).
-          'text-field': getTrackerEmoji(),
-          'text-size': 36,
-          'text-allow-overlap': true,
-          // Use widely supported fonts to avoid 404 errors on Mapbox font API
-          'text-font': ['Open Sans Regular', 'Arial Unicode MS Regular']
-        },
-        paint: {
-          // Use a vibrant orange color with a white halo so the emoji stands out
-          // against any map background.
-          'text-color': '#ff4500',
-          'text-halo-color': '#ffffff',
-          'text-halo-width': 2
-        }
-      });
+
+      // Add the tracker layer if it doesn't already exist. Without this check
+      // Mapbox would throw an error when the layer ID is duplicated.
+      if (!map.getLayer('route-tracker')) {
+        map.addLayer({
+          id: 'route-tracker',
+          type: 'symbol',
+          source: 'route-tracker',
+          layout: {
+            // Tracker emoji indicates the mode of travel. It updates whenever the
+            // navigation mode changes (driving, cycling or walking).
+            'text-field': getTrackerEmoji(),
+            'text-size': 36,
+            'text-allow-overlap': true,
+            // Use widely supported fonts to avoid 404 errors on Mapbox font API
+            'text-font': ['Open Sans Regular', 'Arial Unicode MS Regular']
+          },
+          paint: {
+            // Use a vibrant orange color with a white halo so the emoji stands out
+            // against any map background.
+            'text-color': '#ff4500',
+            'text-halo-color': '#ffffff',
+            'text-halo-width': 2
+          }
+        });
+      }
     } else {
       // If the layer already exists, simply update the source data and ensure
       // the current emoji matches the navigation mode.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.168.0
+Stable tag: 2.169.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.169.0 =
+* Added missing tracker layer check
+* Bumped plugin version
 = 2.168.0 =
 * Bumped plugin version
 = 2.167.0 =


### PR DESCRIPTION
## Summary
- ensure `route-tracker` layer is added only once
- comment tracker layer logic
- bump plugin version to 2.169.0

## Testing
- `php -l gn-mapbox-plugin.php`
- `npx eslint js/mapbox-init.js` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6884f45f9af08327952d5774f103c267