### PR TITLE
[Fix] gate debug logs and correct airport shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.170.0
+- Gated debug logs behind plugin setting
+- Renamed Paphos airport shortcode function
+- Bumped plugin version
 ### 2.169.0
 - Added missing tracker layer check and bumped plugin version
 ### 2.168.0

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.169.0
+Stable tag: 2.170.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,10 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.170.0 =
+* Gated debug logs behind plugin setting
+* Renamed Paphos airport shortcode function
+* Bumped plugin version
 = 2.169.0 =
 * Added missing tracker layer check
 * Bumped plugin version


### PR DESCRIPTION
## Summary
- fix unconditional debug logging with settings check
- rename airport shortcode function for clarity
- bump plugin version to 2.170.0

## Testing
- `php -l gn-mapbox-plugin.php`
- `python3 scripts/verify_proximity.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6884f8da5fe48327b9cfb29635e5f3c9