### PR TITLE
[Fix] Use Mapbox walking icon for navigation tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.173.0
+- Ensure walking tracker uses Mapbox walking icon
+- Bumped plugin version
 ### 2.172.0
 - Fix tracker icon not showing in navigation mode by using Mapbox Maki icons for different navigation modes (car, bicycle and pedestrian)
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.172.0
+Version: 2.173.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -934,13 +934,13 @@
     function getTrackerIcon() {
       if (navigationMode === 'driving') return 'car-15';
       if (navigationMode === 'cycling') return 'bicycle-15';
-      return 'pedestrian-15';
+      return 'walking-15';
     }
-  
+
     function updateTracker(coord) {
       // Convert the provided coordinate into a GeoJSON point so Mapbox GL can
       // easily render it as a layer source. The tracker layer displays a moving
-      // emoji that represents the user's position during navigation.
+      // icon that represents the user's position during navigation.
       const data = { type: 'Feature', geometry: { type: 'Point', coordinates: coord } };
   
       // Log whenever updateTracker runs so we know the function is executing and
@@ -977,7 +977,7 @@
         }
       } else {
         // If the layer already exists, simply update the source data and ensure
-        // the current emoji matches the navigation mode.
+        // the current icon matches the navigation mode.
         console.log('[GN DEBUG]', 'Updating existing route-tracker layer');
         map.getSource('route-tracker').setData(data);
         map.setLayoutProperty('route-tracker', 'icon-image', getTrackerIcon());

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.172.0
+Stable tag: 2.173.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.173.0 =
+* Ensure walking tracker uses Mapbox walking icon
+* Bumped plugin version
 = 2.172.0 =
 * Fix tracker icon not showing in navigation mode by using Mapbox Maki icons for different navigation modes (car, bicycle and pedestrian)
 * Bumped plugin version


### PR DESCRIPTION
## Summary
- ensure navigation tracker uses Mapbox `walking` icon
- bump plugin version to 2.173.0 and refresh changelog

## Testing
- `npx eslint mapbox-init.js` *(fails: ESLint config missing)*
- `php -l gn-mapbox-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_68af3c890b708327b063ed01127cd63f