### PR TITLE
[Fix] Preload navigation mode icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.174.0
+- Preload Mapbox navigation icons and default to driving so tracker icons appear immediately
+- Bumped plugin version
 ### 2.173.0
 - Ensure walking tracker uses Mapbox walking icon
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.173.0
+Version: 2.174.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -13,8 +13,8 @@
     mapboxgl.accessToken = gnMapData.accessToken;
     const debugEnabled = gnMapData.debug === true;
     let coords = [];
-    // default icon shows driving but we actually request walking directions
-    let navigationMode = "walking";
+    // default to driving so the tracker icon matches the initial mode
+    let navigationMode = "driving";
     let map;
     let languageControl;
     let markers = [];
@@ -185,6 +185,7 @@
       const modeSel = navPanel.querySelector("#gn-mode-select");
       if (modeSel) {
         modeSel.value = 'driving';
+        setMode('driving');
         modeSel.onchange = () => setMode(modeSel.value);
       }
   
@@ -923,6 +924,19 @@
     setupNavPanel();
     setupLightbox();
     setupCarousel();
+    function preloadIcons() {
+      const icons = {
+        car: 'https://docs.mapbox.com/mapbox-gl-js/assets/car.png',
+        walking: 'https://docs.mapbox.com/mapbox-gl-js/assets/walking.png',
+        bicycle: 'https://docs.mapbox.com/mapbox-gl-js/assets/bicycle.png'
+      };
+      Object.entries(icons).forEach(([name, url]) => {
+        map.loadImage(url, (err, image) => {
+          if (err) return;
+          if (!map.hasImage(name)) map.addImage(name, image);
+        });
+      });
+    }
     function getTrackerEmoji() {
       if (navigationMode === 'driving') return '🚗';
       if (navigationMode === 'cycling') return '🚲';
@@ -932,9 +946,9 @@
     // Return Mapbox Maki icon name for the current navigation mode.  Using
     // icons instead of emojis ensures the tracker is visible on all systems.
     function getTrackerIcon() {
-      if (navigationMode === 'driving') return 'car-15';
-      if (navigationMode === 'cycling') return 'bicycle-15';
-      return 'walking-15';
+      if (navigationMode === 'driving') return 'car';
+      if (navigationMode === 'cycling') return 'bicycle';
+      return 'walking';
     }
 
     function updateTracker(coord) {
@@ -1024,9 +1038,10 @@
       defaultLanguage: mapLangPart(defaultLang)
     });
     map.addControl(languageControl);
-  
+
     map.on("load", () => {
       log("Map loaded");
+      preloadIcons();
       const routeSel = document.getElementById("gn-route-select");
       if (routeSel) routeSel.value = "default";
       selectRoute("default");

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.173.0
+Stable tag: 2.174.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/locations.json`.
 
 == Changelog ==
+= 2.174.0 =
+* Preload Mapbox navigation icons and default to driving so tracker icons appear immediately
+* Bumped plugin version
 = 2.173.0 =
 * Ensure walking tracker uses Mapbox walking icon
 * Bumped plugin version


### PR DESCRIPTION
## Summary
- preload Mapbox icons for car, walking and bicycle
- default navigation mode to driving and load icons on map start
- bump plugin version to 2.174.0

## Testing
- `php -l gn-mapbox-plugin.php`
- `eslint js/mapbox-init.js` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68af46a70e2c8327b176a4b99103e1a6